### PR TITLE
Msay

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -9,6 +9,7 @@ var/list/admin_verbs_default = list(
 	/client/proc/cmd_event_say,			//VOREStation Add,
 	/client/proc/cmd_mentor_ticket_panel,
 	/client/proc/cmd_mentor_say,
+	/client/proc/cmd_mentor_say_alt,
 //	/client/proc/hide_verbs,			//hides all our adminverbs, //VOREStation Remove,
 //	/client/proc/hide_most_verbs,		//hides all our hideable adminverbs, //VOREStation Remove,
 //	/client/proc/debug_variables,		//allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify, //VOREStation Remove,

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -19,7 +19,7 @@
 
 /client/proc/cmd_mod_say(msg as text)
 	set category = "Special Verbs"
-	set name = "Msay"
+	set name = "Modsay"
 	set hidden = 1
 
 	if(!check_rights(R_ADMIN|R_MOD|R_SERVER)) //VOREStation Edit

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -6,6 +6,7 @@ var/list/mentor_datums = list()
 var/list/mentor_verbs_default = list(
 	/client/proc/cmd_mentor_ticket_panel,
 	/client/proc/cmd_mentor_say,
+	/client/proc/cmd_mentor_say_alt,
 	/client/proc/cmd_dementor
 )
 
@@ -102,6 +103,12 @@ var/list/mentor_verbs_default = list(
 		to_chat(C, create_text_tag("mentor", "MENTOR:", C) + " <span class='mentor_channel'><span class='name'>[src]</span>: <span class='message'>[msg]</span></span>")
 	for(var/client/C in GLOB.admins)
 		to_chat(C, create_text_tag("mentor", "MENTOR:", C) + " <span class='mentor_channel'><span class='name'>[src]</span>: <span class='message'>[msg]</span></span>")
+
+/client/proc/cmd_mentor_say_alt(msg as text)
+	set category = "Admin"
+	set name ="Msay"
+
+	cmd_mentor_say(msg)
 
 /proc/mentor_commands(href, href_list, client/C)
 	if(href_list["mhelp"])


### PR DESCRIPTION
I made msay be mentorsay instead of modsay, and made the old msay be modsay.

Mentorsay actually gets used, modsay doesn't.

Mentorsay still works as a verb, msay just relays to the mentorsay verb.
