### PR TITLE
Preferences adjust

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -438,6 +438,7 @@ var/global/list/##LIST_NAME = list();\
 #define VOLUME_CHANNEL_VORE "Vore"
 #define VOLUME_CHANNEL_DOORS "Doors"
 #define VOLUME_CHANNEL_INSTRUMENTS "Instruments"
+#define VOLUME_CHANNEL_ADMIN_SOUNDS "Admin Sounds"
 
 // Make sure you update this or clients won't be able to adjust the channel
 GLOBAL_LIST_INIT(all_volume_channels, list(
@@ -446,7 +447,8 @@ GLOBAL_LIST_INIT(all_volume_channels, list(
 	VOLUME_CHANNEL_ALARMS,
 	VOLUME_CHANNEL_VORE,
 	VOLUME_CHANNEL_DOORS,
-	VOLUME_CHANNEL_INSTRUMENTS
+	VOLUME_CHANNEL_INSTRUMENTS,
+	VOLUME_CHANNEL_ADMIN_SOUNDS
 ))
 
 #define APPEARANCECHANGER_CHANGED_RACE "Race"

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -13,11 +13,16 @@ var/list/sounds_cache = list()
 	if(tgui_alert(usr, "Do you ready?\nSong: [S]\nNow you can also play this sound using \"Play Server Sound\".", "Confirmation request", list("Play","Cancel")) == "Cancel")
 		return
 
+	var/our_volume = tgui_input_number(usr, "How loud? (1-100)", title = "Volume", default = 100, max_value = 100, min_value = 0)
+
+	if(!our_volume)
+		return
+
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
 	for(var/mob/M in player_list)
 		if(M.is_preference_enabled(/datum/client_preference/play_admin_midis))
-			M << sound(uploaded_sound, channel = VOLUME_CHANNEL_ADMIN_SOUNDS , volume = 100 * M.client.get_preference_volume_channel(VOLUME_CHANNEL_ADMIN_SOUNDS))
+			M << sound(uploaded_sound, channel = VOLUME_CHANNEL_ADMIN_SOUNDS , volume = our_volume * M.client.get_preference_volume_channel(VOLUME_CHANNEL_ADMIN_SOUNDS))
 
 	feedback_add_details("admin_verb","PGS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -26,9 +31,14 @@ var/list/sounds_cache = list()
 	set name = "Play Local Sound"
 	if(!check_rights(R_SOUNDS))	return
 
+	var/our_volume = tgui_input_number(usr, "How loud? (1-100)", title = "Volume", default = 100, max_value = 100, min_value = 0)
+
+	if(!our_volume)
+		return
+
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]", 1)
-	playsound(src.mob, S, 50, 0, 0)
+	playsound(src.mob, S, our_volume , 0, 0, preference = /datum/client_preference/play_admin_midis, volume_channel = VOLUME_CHANNEL_ADMIN_SOUNDS)
 	feedback_add_details("admin_verb","PLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/play_z_sound(S as sound)
@@ -44,11 +54,16 @@ var/list/sounds_cache = list()
 	if(tgui_alert(usr, "Do you ready?\nSong: [S]\nNow you can also play this sound using \"Play Server Sound\".", "Confirmation request", list("Play","Cancel")) == "Cancel")
 		return
 
+	var/our_volume = tgui_input_number(usr, "How loud? (1-100)", title = "Volume", default = 100, max_value = 100, min_value = 0)
+
+	if(!our_volume)
+		return
+
 	log_admin("[key_name(src)] played sound [S] on Z[target_z]")
 	message_admins("[key_name_admin(src)] played sound [S] on Z[target_z]", 1)
 	for(var/mob/M in player_list)
 		if(M.is_preference_enabled(/datum/client_preference/play_admin_midis) && M.z == target_z)
-			M << uploaded_sound
+			M << sound(uploaded_sound, channel = VOLUME_CHANNEL_ADMIN_SOUNDS , volume = our_volume * M.client.get_preference_volume_channel(VOLUME_CHANNEL_ADMIN_SOUNDS))
 
 	feedback_add_details("admin_verb","PZS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -17,7 +17,7 @@ var/list/sounds_cache = list()
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
 	for(var/mob/M in player_list)
 		if(M.is_preference_enabled(/datum/client_preference/play_admin_midis))
-			M << uploaded_sound
+			M << sound(uploaded_sound, channel = VOLUME_CHANNEL_ADMIN_SOUNDS , volume = 100 * M.client.get_preference_volume_channel(VOLUME_CHANNEL_ADMIN_SOUNDS))
 
 	feedback_add_details("admin_verb","PGS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -9,7 +9,6 @@
 	S["ooccolor"]				>> pref.ooccolor
 	S["tooltipstyle"]			>> pref.tooltipstyle
 	S["client_fps"]				>> pref.client_fps
-	S["ambience_freq"]			>> pref.ambience_freq
 	S["ambience_chance"] 		>> pref.ambience_chance
 	S["tgui_fancy"]				>> pref.tgui_fancy
 	S["tgui_lock"]				>> pref.tgui_lock
@@ -26,7 +25,6 @@
 	S["ooccolor"]				<< pref.ooccolor
 	S["tooltipstyle"]			<< pref.tooltipstyle
 	S["client_fps"]				<< pref.client_fps
-	S["ambience_freq"]			<< pref.ambience_freq
 	S["ambience_chance"] 		<< pref.ambience_chance
 	S["tgui_fancy"]				<< pref.tgui_fancy
 	S["tgui_lock"]				<< pref.tgui_lock
@@ -43,7 +41,6 @@
 	pref.ooccolor			= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
 	pref.tooltipstyle		= sanitize_inlist(pref.tooltipstyle, all_tooltip_styles, initial(pref.tooltipstyle))
 	pref.client_fps			= sanitize_integer(pref.client_fps, 0, MAX_CLIENT_FPS, initial(pref.client_fps))
-	pref.ambience_freq		= sanitize_integer(pref.ambience_freq, 0, 60, initial(pref.ambience_freq)) // No more than once per hour.
 	pref.ambience_chance 	= sanitize_integer(pref.ambience_chance, 0, 100, initial(pref.ambience_chance)) // 0-100 range.
 	pref.tgui_fancy			= sanitize_integer(pref.tgui_fancy, 0, 1, initial(pref.tgui_fancy))
 	pref.tgui_lock			= sanitize_integer(pref.tgui_lock, 0, 1, initial(pref.tgui_lock))
@@ -60,7 +57,6 @@
 	. += "-Alpha(transparency): <a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a>�<a href='?src=\ref[src];reset=alpha'>reset</a><br>"
 	. += "<b>Tooltip Style:</b> <a href='?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltipstyle]</b></a><br>"
 	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_client_fps=1'><b>[pref.client_fps]</b></a><br>"
-	. += "<b>Random Ambience Frequency:</b> <a href='?src=\ref[src];select_ambience_freq=1'><b>[pref.ambience_freq]</b></a><br>"
 	. += "<b>Ambience Chance:</b> <a href='?src=\ref[src];select_ambience_chance=1'><b>[pref.ambience_chance]</b></a><br>"
 	. += "<b>TGUI Window Mode:</b> <a href='?src=\ref[src];tgui_fancy=1'><b>[(pref.tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</b></a><br>"
 	. += "<b>TGUI Window Placement:</b> <a href='?src=\ref[src];tgui_lock=1'><b>[(pref.tgui_lock) ? "Primary Monitor" : "Free (default)"]</b></a><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -23,7 +23,7 @@ var/list/preferences_datums = list()
 	var/UI_style_alpha = 255
 	var/tooltipstyle = "Midnight"		//Style for popup tooltips
 	var/client_fps = 40
-	var/ambience_freq = 5				// How often we're playing repeating ambience to a client.
+	var/ambience_freq = 0				// How often we're playing repeating ambience to a client.
 	var/ambience_chance = 35			// What's the % chance we'll play ambience (in conjunction with the above frequency)
 
 	var/tgui_fancy = TRUE


### PR DESCRIPTION
Removes the preference to have ambience repeat when you aren't moving between areas. The random repeating of the sounds makes what is otherwise useful audio design language annoying.

also adds a user volume preference for admin sounds, this allows the user to set a volume level for sounds that staff might play.

ALSO adds a volume input for staff to use when playing sounds, so they can try to be considerate when the sound doesn't need to be super loud.
