### PR TITLE
Updates death

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -17,9 +17,12 @@
 		//VOREStation Edit End
 		nest = null
 
-	if(isbelly(loc) && tf_mob_holder)
-		mind?.vore_death = TRUE
-		tf_mob_holder.mind?.vore_death = TRUE
+	if(isbelly(loc))
+		var/obj/belly/B = loc
+		if(B.digest_mode == DM_DIGEST || B.digest_mode == DM_SELECT)
+			mind?.vore_death = TRUE
+			if(tf_mob_holder)
+				tf_mob_holder.mind?.vore_death = TRUE
 
 	for(var/datum/soul_link/S as anything in owned_soul_links)
 		S.owner_died(gibbed)

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -193,6 +193,7 @@
 
 	log_admin("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
 	message_admins("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
+	new_character.mind?.vore_death = FALSE
 
 	var/obj/item/weapon/implant/backup/imp = new(src)
 


### PR DESCRIPTION
Fixes a problem where process doesn't trigger vore death respawn time.

Also makes the autoresleever reset your vore_death var when used
