### PR TITLE
Remove vore verb traits

### DIFF
--- a/code/game/objects/items/weapons/traps_vr.dm
+++ b/code/game/objects/items/weapons/traps_vr.dm
@@ -3,7 +3,7 @@
 	item_icons = list(
 		slot_wear_mask_str = 'icons/inventory/face/mob_vr.dmi'
 		)
-
+/* RS removal: this verb should just always be on people now
 /obj/item/weapon/beartrap/equipped()
 	if(ishuman(src.loc))
 		var/mob/living/carbon/human/H = src.loc
@@ -16,3 +16,4 @@
 /obj/item/weapon/beartrap/dropped(var/mob/user)
 	user.verbs -= /mob/living/proc/shred_limb_temp
 	..()
+*/

--- a/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
@@ -47,7 +47,7 @@
 	verbs += /mob/living/proc/set_size
 	verbs += /mob/living/proc/hide
 	verbs += /mob/living/simple_mob/proc/animal_nom
-	verbs += /mob/living/proc/shred_limb
+	//verbs += /mob/living/proc/shred_limb - RS remove
 	verbs += /mob/living/simple_mob/slime/promethean/proc/toggle_expand
 	verbs += /mob/living/simple_mob/slime/promethean/proc/prommie_select_colour
 	verbs += /mob/living/simple_mob/slime/promethean/proc/toggle_shine

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -506,7 +506,7 @@
 
 
 //Welcome to the adapted changeling absorb code.
-/mob/living/carbon/human/proc/succubus_drain()
+/mob/living/carbon/human/verb/succubus_drain()
 	set name = "Drain prey of nutrition"
 	set desc = "Slowly drain prey of all the nutrition in their body, feeding you in the process. You may only do this to one person at a time."
 	set category = "Abilities"
@@ -569,7 +569,7 @@
 			C.absorbing_prey = 0
 			return
 
-/mob/living/carbon/human/proc/succubus_drain_lethal()
+/mob/living/carbon/human/verb/succubus_drain_lethal()
 	set name = "Lethally drain prey" //Provide a warning that THIS WILL KILL YOUR PREY.
 	set desc = "Slowly drain prey of all the nutrition in their body, feeding you in the process. Once prey run out of nutrition, you will begin to drain them lethally. You may only do this to one person at a time."
 	set category = "Abilities"
@@ -661,7 +661,7 @@
 			absorbing_prey = 0
 			return
 
-/mob/living/carbon/human/proc/slime_feed()
+/mob/living/carbon/human/verb/slime_feed()
 	set name = "Feed prey with self"
 	set desc = "Slowly feed prey with your body, draining you in the process. You may only do this to one person at a time."
 	set category = "Abilities"
@@ -722,7 +722,7 @@
 			C.absorbing_prey = 0
 			return
 
-/mob/living/carbon/human/proc/succubus_drain_finalize()
+/mob/living/carbon/human/verb/succubus_drain_finalize()
 	set name = "Drain/Feed Finalization"
 	set desc = "Toggle to allow for draining to be prolonged. Turn this on to make it so prey will be knocked out/die while being drained, or you will feed yourself to the prey's selected stomach if you're feeding them. Can be toggled at any time."
 	set category = "Abilities"
@@ -814,7 +814,7 @@
 
 	return ..(target)
 
-/mob/living/proc/shred_limb()
+/mob/living/verb/shred_limb()
 	set name = "Damage/Remove Prey's Organ"
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -181,7 +181,7 @@
 	name_language = LANGUAGE_TERMINUS
 	species_language = LANGUAGE_TERMINUS
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,
-		/mob/living/proc/shred_limb,
+//		/mob/living/proc/shred_limb, - RS REMOVE
 		/mob/living/carbon/human/proc/tie_hair)
 	digi_allowed = TRUE
 
@@ -567,7 +567,7 @@
 	secondary_langs = list(LANGUAGE_TERMINUS)
 	name_language = LANGUAGE_TERMINUS
 	species_language = LANGUAGE_TERMINUS
-	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,/mob/living/proc/shred_limb,/mob/living/carbon/human/proc/tie_hair)
+	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,/mob/living/carbon/human/proc/tie_hair)
 	digi_allowed = TRUE
 
 	min_age = 18

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -124,7 +124,7 @@
 /datum/trait/neutral/bloodsucker_freeform/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
-
+/* - RS removal: made these default verbs
 /datum/trait/neutral/succubus_drain
 	name = "Succubus Drain"
 	desc = "Makes you able to gain nutrition from draining prey in your grasp."
@@ -167,7 +167,7 @@
 /datum/trait/neutral/feeder/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/slime_feed
-
+*/
 /datum/trait/neutral/stuffing_feeder
 	name = "Food Stuffer"
 	desc = "Allows you to feed food to other people whole, rather than bite by bite."
@@ -178,7 +178,7 @@
 /datum/trait/neutral/stuffing_feeder/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/toggle_stuffing_mode
-
+/* - RS removal: made these default verbs
 /datum/trait/neutral/hard_vore
 	name = "Brutal Predation"
 	desc = "Allows you to tear off limbs & tear out internal organs."
@@ -188,7 +188,7 @@
 /datum/trait/neutral/hard_vore/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/shred_limb
-
+*/
 /datum/trait/neutral/trashcan
 	name = "Trash Can"
 	desc = "Allows you to dispose of some garbage on the go instead of having to look for a bin or littering like an animal."
@@ -652,7 +652,7 @@
 /datum/trait/neutral/thinner/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.update_transform()
-
+/* - RS removal: made these default verbs
 /datum/trait/neutral/dominate_predator
 	name = "Dominate Predator"
 	desc = "Allows you to attempt to take control of a predator while inside of their belly."
@@ -692,7 +692,7 @@
 /datum/trait/neutral/vertical_nom/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/vertical_nom
-
+*/
 /datum/trait/neutral/micro_size_down
 	name = "Light Frame"
 	desc = "You are considered smaller than you are for micro interactions."

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -304,7 +304,7 @@
 	var/turf/T = get_turf(src)
 	if(istype(T)) T.visible_message("<span class='filter_notice'><b>[src]</b> folds outwards, expanding into a mobile form.</span>")
 	verbs |= /mob/living/silicon/pai/proc/pai_nom
-	verbs |= /mob/living/proc/vertical_nom
+//	verbs |= /mob/living/proc/vertical_nom - RS REMOVE
 	update_icon()
 
 /mob/living/silicon/pai/verb/fold_up()
@@ -477,7 +477,7 @@
 	if(isopenspace(card.loc))
 		fall()
 	verbs -= /mob/living/silicon/pai/proc/pai_nom
-	verbs -= /mob/living/proc/vertical_nom
+//	verbs -= /mob/living/proc/vertical_nom - RS REMOVE
 
 // No binary for pAIs.
 /mob/living/silicon/pai/binarycheck()

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -69,10 +69,10 @@
 /mob/living/silicon/pai/Initialize()
 	. = ..()
 
-	verbs |= /mob/proc/dominate_predator
-	verbs |= /mob/living/proc/dominate_prey
+//	verbs |= /mob/proc/dominate_predator - RS REMOVE
+//	verbs |= /mob/living/proc/dominate_prey - RS REMOVE
 	verbs |= /mob/living/proc/set_size
-	verbs |= /mob/living/proc/shred_limb
+//	verbs |= /mob/living/proc/shred_limb - RS REMOVE
 
 /mob/living/silicon/pai/Login()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -107,7 +107,7 @@
 		/mob/living/silicon/robot/proc/robot_checklaws,
 		/mob/living/silicon/robot/proc/robot_mount,
 		/mob/living/proc/toggle_rider_reins,
-		/mob/living/proc/shred_limb
+//		/mob/living/proc/shred_limb - RS REMOVE
 	)
 
 /mob/living/silicon/robot/New(loc, var/unfinished = 0)

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -212,7 +212,7 @@
 
 	if(!IsAdvancedToolUser())
 		verbs |= /mob/living/simple_mob/proc/animal_nom
-		verbs |= /mob/living/proc/shred_limb
+//		verbs |= /mob/living/proc/shred_limb - RS REMOVE
 
 	if(LAZYLEN(vore_organs))
 		return
@@ -220,7 +220,7 @@
 	// Since they have bellies, add verbs to toggle settings on them.
 	verbs |= /mob/living/simple_mob/proc/toggle_digestion
 	verbs |= /mob/living/simple_mob/proc/toggle_fancygurgle
-	verbs |= /mob/living/proc/vertical_nom
+//	verbs |= /mob/living/proc/vertical_nom - RS REMOVE
 
 	//A much more detailed version of the default /living implementation
 	var/obj/belly/B = new /obj/belly(src)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -171,7 +171,7 @@
 		languages |= langlist
 
 //Welcome to the adapted borer code.
-/mob/proc/dominate_predator()
+/mob/verb/dominate_predator()
 	set category = "Abilities"
 	set name = "Dominate Predator"
 	set desc = "Connect to and dominate the brain of your predator."
@@ -305,7 +305,7 @@
 	else
 		to_chat(src, "<span class='warning'>\The [pred_body] is already dominated, and cannot be controlled at this time.</span>")
 
-/mob/living/proc/dominate_prey()
+/mob/living/verb/dominate_prey()
 	set category = "Abilities"
 	set name = "Dominate Prey"
 	set desc = "Connect to and dominate the brain of your prey."
@@ -399,7 +399,7 @@
 		to_chat(src, "<span class='warning'>Your body seems to no longer exist, so, you cannot return to it.</span>")
 		verbs -= /mob/living/dominated_brain/proc/cease_this_foolishness
 
-/mob/living/proc/lend_prey_control()
+/mob/living/verb/lend_prey_control()
 	set category = "Abilities"
 	set name = "Give Prey Control"
 	set desc = "Allow prey control of your body."

--- a/code/modules/vore/eating/vertical_nom_vr.dm
+++ b/code/modules/vore/eating/vertical_nom_vr.dm
@@ -1,4 +1,4 @@
-/mob/living/proc/vertical_nom()
+/mob/living/verb/vertical_nom()
 	set name = "Nom from Above"
 	set desc = "Allows you to eat people who are below your tile or adjacent one. Requires passability."
 	set category = "Abilities"


### PR DESCRIPTION
(makes most of the vore verbs from the traits just default verbs that everyone has. The ones that I didn't include either have some kind of selection in the traits menu, or change the default behavior of things, so, those you will still have to take the traits for, but MOST OF the ability verbs aren't locked by traits anymore)
