### PR TITLE
Sprite scaling port

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -14,6 +14,7 @@
 	var/weight_gain = 100	// Weight gain rate.
 	var/weight_loss = 50	// Weight loss rate.
 	var/fuzzy = 0			// Preference toggle for sharp/fuzzy icon. Default sharp.
+	var/offset_override = FALSE
 	var/voice_freq = 0
 	var/voice_sound = "beep-boop"
 	var/custom_speech_bubble = "default"
@@ -29,6 +30,7 @@
 	S["weight_gain"]		>> pref.weight_gain
 	S["weight_loss"]		>> pref.weight_loss
 	S["fuzzy"]				>> pref.fuzzy
+	S["offset_override"]	>> pref.offset_override
 	S["voice_freq"]			>> pref.voice_freq
 	S["voice_sound"]		>> pref.voice_sound
 	S["custom_speech_bubble"]		>> pref.custom_speech_bubble
@@ -39,6 +41,7 @@
 	S["weight_gain"]		<< pref.weight_gain
 	S["weight_loss"]		<< pref.weight_loss
 	S["fuzzy"]				<< pref.fuzzy
+	S["offset_override"]	<< pref.offset_override
 	S["voice_freq"]			<< pref.voice_freq
 	S["voice_sound"]		<< pref.voice_sound
 	S["custom_speech_bubble"]		<< pref.custom_speech_bubble
@@ -48,6 +51,7 @@
 	pref.weight_gain		= sanitize_integer(pref.weight_gain, WEIGHT_CHANGE_MIN, WEIGHT_CHANGE_MAX, initial(pref.weight_gain))
 	pref.weight_loss		= sanitize_integer(pref.weight_loss, WEIGHT_CHANGE_MIN, WEIGHT_CHANGE_MAX, initial(pref.weight_loss))
 	pref.fuzzy				= sanitize_integer(pref.fuzzy, 0, 1, initial(pref.fuzzy))
+	pref.offset_override	= sanitize_integer(pref.offset_override, 0, 1, initial(pref.offset_override))
 	if(pref.voice_freq != 0)
 		pref.voice_freq			= sanitize_integer(pref.voice_freq, MIN_VOICE_FREQ, MAX_VOICE_FREQ, initial(pref.fuzzy))
 	if(pref.size_multiplier == null || pref.size_multiplier < RESIZE_TINY || pref.size_multiplier > RESIZE_HUGE)
@@ -60,6 +64,7 @@
 	character.weight_gain		= pref.weight_gain
 	character.weight_loss		= pref.weight_loss
 	character.fuzzy				= pref.fuzzy
+	character.offset_override	= pref.offset_override
 	character.voice_freq		= pref.voice_freq
 	character.resize(pref.size_multiplier, animate = FALSE, ignore_prefs = TRUE)
 	if(!pref.voice_sound)
@@ -100,6 +105,7 @@
 	. += "<br>"
 	. += "<b>Scale:</b> <a href='?src=\ref[src];size_multiplier=1'>[round(pref.size_multiplier*100)]%</a><br>"
 	. += "<b>Scaled Appearance:</b> <a [pref.fuzzy ? "" : ""] href='?src=\ref[src];toggle_fuzzy=1'><b>[pref.fuzzy ? "Fuzzy" : "Sharp"]</b></a><br>"
+	. += "<b>Scaling Center:</b> <a [pref.offset_override ? "" : ""] href='?src=\ref[src];toggle_offset_override=1'><b>[pref.offset_override ? "Odd" : "Even"]</b></a><br>"
 	. += "<b>Voice Frequency:</b> <a href='?src=\ref[src];voice_freq=1'>[pref.voice_freq]</a><br>"
 	. += "<b>Voice Sounds:</b> <a href='?src=\ref[src];voice_sounds_list=1'>[pref.voice_sound]</a><br>"
 	. += "<a href='?src=\ref[src];voice_test=1'><b>Test Selected Voice</b></a><br>"
@@ -122,6 +128,10 @@
 
 	else if(href_list["toggle_fuzzy"])
 		pref.fuzzy = pref.fuzzy ? 0 : 1;
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["toggle_offset_override"])
+		pref.offset_override = pref.offset_override ? 0 : 1;
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["weight"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1202,6 +1202,7 @@
 		species.remove_inherent_verbs(src)
 		holder_type = null
 		hunger_rate = initial(hunger_rate) //VOREStation Add
+		center_offset = species.center_offset
 
 	species = GLOB.all_species[new_species]
 

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -38,6 +38,7 @@
 	var/micro_size_mod = 0		// How different is our size for interactions that involve us being small?
 	var/macro_size_mod = 0		// How different is our size for interactions that involve us being big?
 	var/digestion_nutrition_modifier = 1
+	var/center_offset = 0.5
 	var/can_climb = FALSE
 	var/climbing_delay = 1.5	// We climb with a quarter delay
 

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -23,6 +23,7 @@
 	female_cough_sounds = list('sound/effects/mob_effects/tesharicougha.ogg','sound/effects/mob_effects/tesharicoughb.ogg')
 	male_sneeze_sound = 'sound/effects/mob_effects/tesharisneeze.ogg'
 	female_sneeze_sound = 'sound/effects/mob_effects/tesharisneeze.ogg'
+	center_offset = 0
 
 	blood_color = "#D514F7"
 	flesh_color = "#5F7BB0"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -119,7 +119,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	//Do any species specific layering updates, such as when hiding.
 	update_icon_special()
 
-/mob/living/carbon/human/update_transform()
+/mob/living/carbon/human/update_transform(var/instant = FALSE)
 	/* VOREStation Edit START
 	// First, get the correct size.
 	var/desired_scale_x = icon_scale_x
@@ -138,6 +138,9 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/desired_scale_y = size_multiplier * icon_scale_y
 	desired_scale_x *= species.icon_scale_x
 	desired_scale_y *= species.icon_scale_y
+	var/cent_offset = species.center_offset
+	if(fuzzy || offset_override || dir == EAST || dir == WEST)
+		cent_offset = 0
 	vis_height = species.icon_height
 	appearance_flags |= PIXEL_SCALE
 	if(fuzzy)
@@ -167,14 +170,18 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			else
 				M.Translate(1,-6)
 			M.Scale(desired_scale_y, desired_scale_x)
+		M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1))
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else
 		M.Scale(desired_scale_x, desired_scale_y)//VOREStation Edit
-		M.Translate(0, (vis_height/2)*(desired_scale_y-1)) //VOREStation edit
+		M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1))
 		if(tail_style?.can_loaf) // VOREStation Edit: Taur Loafing
 			update_tail_showing() // VOREStation Edit: Taur Loafing
 		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
-
+	if(instant)
+		transform = M
+	else
+		animate(src, transform = M, time = anim_time)
 	animate(src, transform = M, time = anim_time)
 	update_icon_special() //May contain transform-altering things
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1014,7 +1014,7 @@
 	// First, get the correct size.
 	var/desired_scale_x = size_multiplier * icon_scale_x //VOREStation edit
 	var/desired_scale_y = size_multiplier * icon_scale_y //VOREStation edit
-	var/center_offset = center_offset
+	var/cent_offset = center_offset
 	// Now for the regular stuff.
 	if(fuzzy || offset_override || dir == EAST || dir == WEST)
 		cent_offset = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1010,15 +1010,17 @@
 		if(!isnull(M.icon_scale_y_percent))
 			. *= M.icon_scale_y_percent
 
-/mob/living/update_transform()
+/mob/living/update_transform(var/instant = FALSE)
 	// First, get the correct size.
 	var/desired_scale_x = size_multiplier * icon_scale_x //VOREStation edit
 	var/desired_scale_y = size_multiplier * icon_scale_y //VOREStation edit
-
+	var/center_offset = center_offset
 	// Now for the regular stuff.
+	if(fuzzy || offset_override || dir == EAST || dir == WEST)
+		cent_offset = 0
 	var/matrix/M = matrix()
 	M.Scale(desired_scale_x, desired_scale_y)
-	M.Translate(0, (vis_height/2)*(desired_scale_y-1)) //VOREStation edit
+	M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1))
 	src.transform = M //VOREStation edit
 	handle_status_indicators()
 
@@ -1301,3 +1303,8 @@
 	icon = 'icons/mob/screen/midnight.dmi'
 	icon_state = "character"
 	screen_loc = ui_smallquad
+
+/mob/living/set_dir(var/new_dir)
+	. = ..()
+	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
+		update_transform(TRUE)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -19,6 +19,7 @@
 	verbs |= /mob/living/proc/lick
 	verbs |= /mob/living/proc/smell
 	verbs |= /mob/living/proc/switch_scaling
+	verbs |= /mob/living/proc/center_offset
 
 	if(!no_vore)
 		verbs |= /mob/living/proc/vorebelly_printout

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1013,6 +1013,14 @@
 	set desc = "Switch sharp/fuzzy scaling for current mob."
 	appearance_flags ^= PIXEL_SCALE
 	fuzzy = !fuzzy
+	update_transform()
+
+/mob/living/proc/center_offset()
+	set name = "Switch center offset mode"
+	set category = "Preferences"
+	set desc = "Switch sprite center offset to fix even/odd symmetry."
+	offset_override = !offset_override
+	update_transform()
 
 /mob/living/examine(mob/user, infix, suffix)
 	. = ..()

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -7,6 +7,8 @@
 /mob/living
 	var/holder_default
 	var/pickup_active = TRUE			// Toggle whether your help intent picks up micros or pets them
+	var/center_offset = 0.5				// Center offset for uneven scaling symmetry.
+	var/offset_override = FALSE			// Pref toggle for center offset.
 
 // Define holder_type on types we want to be scoop-able
 /mob/living/carbon/human
@@ -30,9 +32,12 @@
 /mob/living/update_icons()
 	. = ..()
 	ASSERT(!ishuman(src))
+	var/cent_offset = center_offset
+	if(fuzzy || offset_override || dir == EAST || dir == WEST)
+		cent_offset = 0
 	var/matrix/M = matrix()
 	M.Scale(size_multiplier * icon_scale_x, size_multiplier * icon_scale_y)
-	M.Translate(0, (vis_height/2)*(size_multiplier-1))
+	M.Translate(cent_offset * size_multiplier * icon_scale_x, (vis_height/2)*(size_multiplier-1))
 	transform = M
 
 /**


### PR DESCRIPTION
Ports the sprite scaling fix up-ported to [VOREStation](https://github.com/VOREStation/VOREStation/pull/15519), which was originally created on [CHOMPStation](https://github.com/CHOMPStation2). 

This fix allows you to adjust your sprite scaling value, which can allow for a more even sprites at nonstandard intervals (ie, no more misshapen eye sprites.) Like with the up-port to VORE, the scaling value defaults to 'odd' which is unchanged from current values.