### PR TITLE
Allow tgui dev server to work on Windows

### DIFF
--- a/tgui/packages/tgui-dev-server/util.js
+++ b/tgui/packages/tgui-dev-server/util.js
@@ -19,6 +19,7 @@ export const resolveGlob = (...sections) => {
   const unsafePaths = globPkg.sync(path.resolve(...sections), {
     strict: false,
     silent: true,
+    windowsPathsNoEscape: true,
   });
   const safePaths = [];
   for (let path of unsafePaths) {


### PR DESCRIPTION
While helping Poojawa with something, I learned that the tgui dev server does not work on Windows. Leshana helped me figure out exactly why.

The reason is because path sections get passed into resolveGlob() (the function this commit updates) and are constructed into a single path using path.resolve(), which selects the appropriate path delimiter (so / or \\) depending on whether we're on a Windows or POSIX OS. This 'pretty' version of the assembled path is passed into globPkg.sync(), however, per the glob documentation at https://www.npmjs.com/package/glob : 

> Note Glob patterns should always use / as a path separator, even on Windows systems, as \ is used to escape glob characters. If you wish to use \ as a path separator instead of using it as an escape character on Windows platforms, you may set windowsPathsNoEscape:true in the options. In this mode, special glob characters cannot be escaped, making it impossible to match a literal * ? and so on in filenames.

There is unfortunately no method in node's path module to have it create a pretty path that satisfies this. You can use path.posix.reseolve() to force it to use POSIX-style paths, however this removes the drive letter from the start, which then breaks the path lookup by globPkg on Windows. It needs to be something like `C:/Users/Name/Documents/BYOND/cache`, but path.posix.resolve() would return `/Users/Name/Documents/BYOND/cache` and path.resolve() by itself on Windows returns `C:\Users\Name\Documents\BYOND\cache`

The workaround provided in the documentation is sufficient to fix this, adding the windowsPathsNoEscape option. This will break anywhere that uses resolveGlob to resolve literal * and ? in path names, but I could not find any places that do this. They only use * and ? as wildcards, not as literals.