### PR TITLE
Less camping

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -305,6 +305,8 @@ var/list/gamemode_cache = list()
 	var/static/suggested_byond_version
 	var/static/suggested_byond_build
 
+	var/static/job_camp_time_limit = 10 MINUTES		//RS ADD
+
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
 	for (var/T in L)
@@ -1051,7 +1053,10 @@ var/list/gamemode_cache = list()
 
 				if("loadout_whitelist")
 					config.loadout_whitelist = text2num(value)
-
+				//RS ADD START
+				if("job_camp_time_limit")
+					config.job_camp_time_limit = value MINUTES
+				//RS ADD END
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -25,7 +25,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimum_character_age = 25
 	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 14)
 	ideal_character_age = 70 // Old geezer captains ftw
-	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 55) /// Vatborn live shorter, no other race eligible for captain besides human/skrell 
+	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 55) /// Vatborn live shorter, no other race eligible for captain besides human/skrell
 	banned_job_species = list(SPECIES_UNATHI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "mechanical", "digital")
 
 	outfit_type = /decl/hierarchy/outfit/job/captain
@@ -33,7 +33,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 						they do not understand everything, and are expected to delegate tasks to the appropriate crew member. The Site Manager is expected to \
 						have an understanding of Standard Operating Procedure, and is subject to it, and legal action, in the same way as every other crew member."
 	alt_titles = list("Overseer"= /datum/alt_title/overseer)
-
+	camp_protection = TRUE		//RS ADD
 
 /*
 /datum/job/captain/equip(var/mob/living/carbon/human/H)
@@ -93,7 +93,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
-
+	camp_protection = TRUE		//RS ADD
 // HOP Alt Titles
 /datum/alt_title/cro
 	title = "Crew Resources Officer"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -106,6 +106,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
 	job_description = "The Quartermaster manages the Supply department, checking cargo orders and ensuring supplies get to where they are needed."
 	alt_titles = list("Supply Chief" = /datum/alt_title/supply_chief)
+	camp_protection = TRUE		//RS ADD
 
 // Quartermaster Alt Titles
 /datum/alt_title/supply_chief

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -37,6 +37,7 @@
 	job_description = "The Chief Engineer manages the Engineering Department, ensuring that the Engineers work on what needs to be done, handling distribution \
 						of manpower as much as they handle hands-on operations and repairs. They are also expected to keep the rest of the station informed of \
 						any structural threats to the station that may be hazardous to health or disruptive to work."
+	camp_protection = TRUE		//RS ADD
 
 //////////////////////////////////
 //			Engineer

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -39,6 +39,10 @@
 	// Description of the job's role and minimum responsibilities.
 	var/job_description = "This Job doesn't have a description! Please report it!"
 
+	var/camp_protection = FALSE				//RS ADD
+	var/list/restricted_keys = list()		//RS ADD
+	var/list/shift_keys = list()			//RS ADD
+
 /datum/job/New()
 	. = ..()
 	department_accounts = department_accounts || departments_managed
@@ -184,3 +188,10 @@
 	if(brain_type in banned_job_species)
 		return TRUE
 	*/
+
+//RS ADD START
+/datum/job/proc/register_shift_key(key)
+	if(key)
+		var/list/keylist = list(key)
+		SSjob.shift_keys[title] += keylist
+//RS ADD END

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -34,7 +34,7 @@
 						staff keep the station's crew healthy and whole. They are primarily interested in making sure that patients are safely found and \
 						transported to Medical for treatment. They are expected to keep the crew informed about threats to their health and safety, and \
 						about the importance of Suit Sensors."
-
+	camp_protection = TRUE		//RS ADD
 //////////////////////////////////
 //		Medical Doctor
 //////////////////////////////////

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -37,7 +37,7 @@
 						might originate from Research. The Research Director often has at least passing knowledge of most of the Research department, but \
 						are encouraged to allow their staff to perform their own duties."
 	alt_titles = list("Research Supervisor" = /datum/alt_title/research_supervisor)
-
+	camp_protection = TRUE		//RS ADD
 
 // Research Director Alt Titles
 /datum/alt_title/research_supervisor

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -35,7 +35,7 @@
 						keep the other Department Heads, and the rest of the crew, aware of developing situations that may be a threat. If necessary, the HoS may \
 						perform the duties of absent Security roles, such as distributing gear from the Armory."
 	alt_titles = list("Security Commander" = /datum/alt_title/sec_commander, "Chief of Security" = /datum/alt_title/sec_chief)
-
+	camp_protection = TRUE		//RS ADD
 
 // Head of Security Alt Titles
 /datum/alt_title/sec_commander
@@ -69,7 +69,7 @@
 						prisoners that have been processed and brigged, and are responsible for their well being. The Warden is also in charge of distributing \
 						Armoury gear in a crisis, and retrieving it when the crisis has passed. In an emergency, the Warden may be called upon to direct the \
 						Security Department as a whole."
-
+	camp_protection = TRUE		//RS ADD
 //////////////////////////////////
 //			Detective
 //////////////////////////////////

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -76,6 +76,10 @@ var/global/datum/controller/occupations/job_master
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 			unassigned -= player
 			job.current_positions++
+			//RS ADD START
+			if(job.camp_protection && round_duration_in_ds < transfer_controller.shift_hard_end - 30 MINUTES)
+				job.register_shift_key(player.client.ckey)
+			//RS ADD END
 			return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -172,6 +172,14 @@
 		return
 	if(newassignment != newjob.title && !(newassignment in newjob.alt_titles))
 		return
+//RS ADD START
+	if(newjob.camp_protection && round_duration_in_ds < config.job_camp_time_limit)
+		if(SSjob.restricted_keys.len)
+			var/list/check = SSjob.restricted_keys[newjob.title]
+			if(usr.client.ckey in check)
+				to_chat(src,"<span class = 'danger'>[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((config.job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				return
+//RS ADD END
 	if(newjob)
 		card.access = newjob.get_access()
 		card.rank = newjob.title

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -181,6 +181,7 @@
 				return
 //RS ADD END
 	if(newjob)
+		newjob.register_shift_key(usr.client.ckey)
 		card.access = newjob.get_access()
 		card.rank = newjob.title
 		card.assignment = newassignment

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -70,6 +70,15 @@
 			pass = FALSE
 			to_chat(src,"<span class='warning'>Your custom species is not playable. Reconfigure your traits on the VORE tab.</span>")
 
+	//RS ADD START
+	if(J.camp_protection && round_duration_in_ds < config.job_camp_time_limit)
+		if(SSjob.restricted_keys.len)
+			var/list/check = SSjob.restricted_keys[J.title]
+			if(client.ckey in check)
+				to_chat(src,"<span class = 'danger'>[J.title] is not presently selectable because you played as it last round. It will become available to you in [round((config.job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				pass = FALSE
+	//RS ADD END
+
 	//Final popup notice
 	if (!pass)
 		tgui_alert_async(src,"There were problems with spawning your character. Check your message log for details.","Error")


### PR DESCRIPTION
Makes it so that, when playing as very limited (command/adjacent) jobs, on the following shift, one will need to wait 10 minutes before being able to play the same job.

This should help mitigate situations where someone wants to play a limited job, but it's always held by the same individual.

While it's not against the rules or even especially discouraged to play the same job multiple shifts in a row, it can be discouraging to others who might otherwise like to play. Therefore I thought it might be good to allow a short period where someone else can take a turn if they want to.

This is far from a perfect solution. I'm not especially happy about making it a waiting period, but that seemed the best balance, since we do not have a long pregame lobby, so relying on something like a weighted chance on readying up wouldn't be very fit for purpose here.

I did make it so that it will not restrict you on the following shift if you joined within the last 30 minutes. So if you join on the very tail end of a shift, you won't have to worry about waiting at the start of the next one, though, this element has not been widely tested locally. I did confirm it works, but there might be some conditions where it will need some tweaking.

Affects:
Captain
HOP
HOS
CMO
RD
CE
QM
Warden