### PR TITLE
Port Trash Eater Throw Vore from CHOMPStation PR#5987

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -423,6 +423,14 @@ emp_act
 
 	if(istype(AM,/obj/))
 		var/obj/O = AM
+		//RSEdit Start || Ports trash eater throw vore from CHOMPStation, PR#5987
+		if(stat != DEAD && istype(O,/obj/item) && trash_catching && vore_selected)
+			var/obj/item/I = O
+			if(adminbus_trash || is_type_in_list(I,edible_trash) && I.trash_eatable && !is_type_in_list(I,item_vore_blacklist))
+				visible_message("<span class='warning'>[I] is thrown directly into [src]'s [lowertext(vore_selected.name)]!</span>")
+				I.throwing = 0
+				I.forceMove(vore_selected)
+				return //RSEdit End
 		if(in_throw_mode && speed <= THROWFORCE_SPEED_DIVISOR)	//empty active hand and we're in throw mode
 			if(canmove && !restrained())
 				if(isturf(O.loc))

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -199,6 +199,7 @@
 /datum/trait/neutral/trashcan/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/eat_trash
+	H.verbs |= /mob/living/proc/toggle_trash_catching //RSEdit || Ports trash eater throw vore from CHOMPStation, PR#5987
 
 /datum/trait/neutral/gem_eater
 	name = "Expensive Taste"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -257,6 +257,13 @@
 /mob/living/hitby(atom/movable/AM as mob|obj,var/speed = THROWFORCE_SPEED_DIVISOR)//Standardization and logging -Sieve
 	if(istype(AM,/obj/))
 		var/obj/O = AM
+		if(stat != DEAD && istype(O,/obj/item) && trash_catching && vore_selected) //RSEdit Start || Ports trasheater throw vore from CHOMPStation PR#5987
+			var/obj/item/I = O
+			if(adminbus_trash || is_type_in_list(I,edible_trash) && I.trash_eatable && !is_type_in_list(I,item_vore_blacklist))
+				visible_message("<span class='warning'>[I] is thrown directly into [src]'s [lowertext(vore_selected.name)]!</span>")
+				I.throwing = 0
+				I.forceMove(vore_selected)
+				return //RSEdit End
 		var/dtype = O.damtype
 		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)
 
@@ -347,6 +354,9 @@
 			add_attack_logs(thrown_mob.LAssailant,src,"Was Devoured by [thrown_mob.name] via throw vore.")
 			return
 	//VORESTATION EDIT END - Allows for thrown vore!
+
+
+
 
 /mob/living/proc/on_throw_vore_special(var/pred = TRUE, var/mob/living/target)
 	return

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -26,6 +26,7 @@
 	var/vis_height = 32					// Sprite height used for resize features.
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
+	var/trash_catching = FALSE //RSEdit: Toggle for trash throw vore || Ports trash eater throw vore from CHOMPStation PR#5987
 	var/regen_sounds = list(
 		'sound/effects/mob_effects/xenochimera/regen_1.ogg',
 		'sound/effects/mob_effects/xenochimera/regen_2.ogg',
@@ -1021,6 +1022,13 @@
 	set desc = "Switch sprite center offset to fix even/odd symmetry."
 	offset_override = !offset_override
 	update_transform()
+
+/mob/living/proc/toggle_trash_catching()
+	set name = "Toggle Trash Catching"
+	set category = "Abilities"
+	set desc = "Toggle Trash Eater throw vore abilities."
+	trash_catching = !trash_catching
+	to_chat(src, "<span class='warning'>Trash catching [trash_catching ? "enabled" : "disabled"].</span>")
 
 /mob/living/examine(mob/user, infix, suffix)
 	. = ..()


### PR DESCRIPTION
This ports the trash eater throw vore functionality from [CHOMPStation PR #5987](https://github.com/CHOMPStation2/CHOMPStation2/pull/5987). Characters with the **Trash Can** trait can toggle the ability trash-eat thrown items. Items will go into the active vorebelly.