### PR TITLE
Keep Ghosts in Vorebellies

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -271,10 +271,22 @@
 	STOP_PROCESSING(SSbellies, src)
 	owner?.vore_organs?.Remove(src)
 	owner = null
+	for(var/mob/observer/G in src)
+		G.forceMove(get_turf(src)) //RSEdit: Ports kicking ghosts out of deleted vorgans, CHOMPStation PR#7132
 	return ..()
 
 // Called whenever an atom enters this belly
 /obj/belly/Entered(atom/movable/thing, atom/OldLoc)
+
+	if(istype(thing, /mob/observer)) //RSEdit: Ports keeping a ghost in a vorebelly, CHOMPStation PR#4172
+		if(desc) //RSEdit: Ports letting ghosts see belly descriptions on transfer
+			//Allow ghosts see where they are if they're still getting squished along inside.
+			var/formatted_desc
+			formatted_desc = replacetext(desc, "%belly", lowertext(name)) //replace with this belly's name
+			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
+			formatted_desc = replacetext(formatted_desc, "%prey", thing) //replace with whatever mob entered into this belly
+			to_chat(thing, "<span class='notice'><B>[formatted_desc]</B></span>")
+
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
 
@@ -834,7 +846,9 @@
 	//Incase they have the loop going, let's double check to stop it.
 	M.stop_sound_channel(CHANNEL_PREYLOOP)
 	// Delete the digested mob
-	M.ghostize() // Make sure they're out, so we can copy attack logs and such.
+	var/mob/observer/G = M.ghostize() //RSEdit start || Ports keeping a ghost in a vorebelly, CHOMPStation PR#3074 || Make sure they're out, so we can copy attack logs and such.
+	if(G)
+		G.forceMove(src) //RSEdit end.
 	qdel(M)
 
 // Handle a mob being absorbed

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -278,8 +278,8 @@
 // Called whenever an atom enters this belly
 /obj/belly/Entered(atom/movable/thing, atom/OldLoc)
 
-	if(istype(thing, /mob/observer)) //RSEdit: Ports keeping a ghost in a vorebelly, CHOMPStation PR#4172
-		if(desc) //RSEdit: Ports letting ghosts see belly descriptions on transfer
+	if(istype(thing, /mob/observer)) //RSEdit: Ports keeping a ghost in a vorebelly, CHOMPStation PR#3072
+		if(desc) //RSEdit: Ports letting ghosts see belly descriptions on transfer, CHOMPStation PR#4772
 			//Allow ghosts see where they are if they're still getting squished along inside.
 			var/formatted_desc
 			formatted_desc = replacetext(desc, "%belly", lowertext(name)) //replace with this belly's name


### PR DESCRIPTION
Ports three PRs from CHOMPStation. [PR3074](https://github.com/CHOMPStation2/CHOMPStation2/pull/3074), which keeps ghosts inside of a vorebelly after digestion death. [PR4772](https://github.com/CHOMPStation2/CHOMPStation2/pull/4772), which lets ghosts see vorebelly descriptions on transfer. And [PR7132](https://github.com/CHOMPStation2/CHOMPStation2/pull/7132), which is a bugfix to ensure ghosts are not deleted in the event of vorgan deletion through whatever means.