### PR TITLE
Communication Fixes

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -219,7 +219,12 @@
 				if(M)
 					if(isobserver(M))
 						message = "<span class='emote'><B>[src]</B> ([ghost_follow_link(src, M)]) [input]</span>"
-					M.show_message(message, m_type)
+					//RSEdit start: Ports CHOMPStation PR4296 || If you are in the same tile, right next to, or being held by a person doing an emote, you should be able to see it while blind
+					if(m_type != AUDIBLE_MESSAGE && (src.Adjacent(M) || (istype(src.loc, /obj/item/weapon/holder) && src.loc.loc == M)))
+						M.show_message(message)
+					else
+						M.show_message(message, m_type)
+					//RSEdit end
 					M.create_chat_message(src, "[runemessage]", FALSE, list("emote"), (m_type == AUDIBLE_MESSAGE))
 					if(isliving(M))
 						var/mob/living/L = M

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -363,7 +363,7 @@ var/list/channel_to_radio_key = new
 
 			if(M && src) //If we still exist, when the spawn processes
 				//VOREStation Add - Ghosts don't hear whispers
-				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !M.client?.holder)
+				if(whispering && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) || (isbelly(M.loc) && src == M.loc:owner)) && isobserver(M) && !M.client?.holder) //RSEdit: Ports CHOMPStation PR4296
 					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
 					return
 				//VOREStation Add End
@@ -424,7 +424,7 @@ var/list/channel_to_radio_key = new
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/verb_understood="gestures", var/datum/language/language, var/type = 1)
 	var/turf/T = get_turf(src)
 	//We're in something, gesture to people inside the same thing
-	if(loc != T)
+	if(loc != T && !istype(loc, /obj/item/weapon/holder)) //RSEdit: Ports CHOMPStation PR4296 || Partially fixes sign language while being held.
 		for(var/mob/M in loc)
 			M.hear_signlang(message, verb, verb_understood, language, src, type)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -108,8 +108,20 @@
 	if(speaking.flags & NONVERBAL)
 		if(sdisabilities & BLIND || blinded)
 			return FALSE
-		if(!other || !(other in view(src)))
+		if(!other) //RSEdit start: Ports CHOMPStation PR4296 || Fixes seeing non-verbal languages while being held
 			return FALSE
+		if(istype(other.loc, /obj/item/weapon/holder))
+			if(istype(src.loc, /obj/item/weapon/holder))
+				if(!(other.loc in view(src.loc.loc)))
+					return FALSE
+			else if(!(other.loc in view(src)))
+				return FALSE
+		else if(istype(src.loc, /obj/item/weapon/holder))
+			if(!other in view(src.loc.loc))
+				return FALSE
+		else if(!other in view(src))
+			return FALSE
+		//RS Edit end
 
 	//Language check.
 	for(var/datum/language/L in languages)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -117,9 +117,9 @@
 			else if(!(other.loc in view(src)))
 				return FALSE
 		else if(istype(src.loc, /obj/item/weapon/holder))
-			if(!other in view(src.loc.loc))
+			if(!(other in view(src.loc.loc)))
 				return FALSE
-		else if(!other in view(src))
+		else if(!(other in view(src)))
 			return FALSE
 		//RS Edit end
 

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -224,7 +224,7 @@
 		for(var/mob/M as anything in vis_mobs)
 			if(isnewplayer(M))
 				continue
-			if(isobserver(M) && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
+			if(isobserver(M) && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) || (isbelly(M.loc) && src == M.loc:owner)) && !M.client?.holder) //RS edit: Ports CHOMPStation PR4296 || Ghosts in vorebellies can see messages even if the pred has ghost privacy on
 				spawn(0)
 					M.show_message(undisplayed_message, 2)
 			else

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -294,7 +294,7 @@
 	to_chat(owner,"<span class='notice'>[thing] slides into your [lowertext(name)].</span>")
 
 	//Sound w/ antispam flag setting
-	if(vore_sound && !recent_sound)
+	if(vore_sound && !recent_sound  && !istype(thing, /mob/observer)) //RSEdit: Ports VOREStation PR15918 || does not play vorebelly insertion sound upon ghost entering
 		var/soundfile
 		if(!fancy_vore)
 			soundfile = classic_vore_sounds[vore_sound]


### PR DESCRIPTION
Ports CHOMPStation [PR4296](https://github.com/CHOMPStation2/CHOMPStation2/pull/4296) and a line of code from VOREStation [PR15918](https://github.com/VOREStation/VOREStation/pull/15918)

This fix allows for players to see nonverbal languages while being held by another player (such as sign), and allows for blinded players to see emotes when they are directly adjacent to them. It also ports ghosts inside of vorebellies being able to see subtles made by those who have ghost privacy off. The VOREStation port removes the insertion sound a ghost makes when entering the belly upon digestion death.