### PR TITLE
Add typecheck to subtle proc

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -192,8 +192,8 @@
 					var/mob/living/itsme = src
 					if(itsme.vore_organs.len)
 						for(var/obj/belly/ourbelly in itsme.vore_organs)
-							for(var/anything in ourbelly.contents)
-								vis_objs |= anything
+							for(var/obj/O in ourbelly.contents)
+								vis_objs |= O
 
 				for(var/obj/O in vis_objs)	//Let's see if there is anything that might have mobs in it around!
 					if(istype(O,/obj/effect/overmap/visitable/ship))	//Let's look for ships!


### PR DESCRIPTION
This needs a typecheck as bellies have more than just /obj in them and that's all that should be in vis_objs, as later we call (blindly, without typecheck for speed reasons), see_emote() which is an /obj proc on each of the members of vis_objs.