### PR TITLE
Forces Welding tools to update_icon() after refill

### DIFF
--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -157,6 +157,7 @@
 			O.reagents.trans_to_obj(src, max_fuel)
 			to_chat(user, "<span class='notice'>Welder refueled</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
+			update_icon()
 			return
 		else if(!welding)
 			to_chat(user, "<span class='notice'>[src] doesn't use fuel.</span>")

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -154,6 +154,9 @@
 	if(!proximity) return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1)
 		if(!welding && max_fuel)
+			if(get_fuel() == max_fuel)
+				to_chat(user, "<span class='notice'>Welder is already topped off!</span>")
+				return
 			O.reagents.trans_to_obj(src, max_fuel)
 			to_chat(user, "<span class='notice'>Welder refueled</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)


### PR DESCRIPTION
Also puts a safeguard to prevent update_icon() overloading if already full.

This annoyed me.

So I'm fixing it.