### PR TITLE
Fixes missing Air Control Sensors

### DIFF
--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -1917,9 +1917,6 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 1
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/monitoring)
 "dU" = (
@@ -4443,6 +4440,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/aftport)
+"ju" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "phoron_tank";
+	name = "Phoron Reserves"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/storage)
 "jv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -4634,6 +4640,16 @@
 "jQ" = (
 /turf/simulated/floor/reinforced,
 /area/quartermaster/storage)
+"jR" = (
+/obj/machinery/computer/general_air_control{
+	dir = 1;
+	frequency = 1443;
+	level = 3;
+	name = "Atmospheric Storage Monitor";
+	sensors = list("dist_main_meter"="Distribution Loop","scrub_main_meter"="Scrubbers Loop","mair_main_meter"="Mixed Air Tank","dist_aux_meter"="Mixed Air to Aux","n2_tank"="Nitrogen Reserves","o2_tank"="Oxygen Reserves","no2_tank"="Nitrous Oxide Reserves","phoron_tank"="Phoron Reserves","co2_tank"="Carbon Dioxide Reserves","engine_fuel"="Engine Fuel")
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/atmos/monitoring)
 "jS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5497,7 +5513,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_main_meter";
+	name = "Distribution Meter"
+	},
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
@@ -9259,6 +9279,15 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/engineering/storage)
+"tY" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "n2_tank";
+	name = "Nitrogen Reserves"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/storage)
 "tZ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -10711,7 +10740,11 @@
 /area/engineering/atmos/monitoring)
 "xu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "no2_tank";
+	name = "Nitrous Oxide Reserves"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "xv" = (
@@ -11528,6 +11561,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
+"ze" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "co2_tank";
+	name = "Carbon Dioxide Reserves"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/storage)
 "zf" = (
 /obj/machinery/light{
 	dir = 4
@@ -11537,6 +11579,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/aftport)
+"zg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "o2_tank";
+	name = "Oxygen Reserves"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/storage)
 "zh" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /turf/simulated/floor/tiled,
@@ -11976,7 +12027,11 @@
 /turf/simulated/floor,
 /area/engineering/atmos/monitoring)
 "An" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Air mix to Aux"
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
@@ -13723,16 +13778,6 @@
 	},
 /turf/simulated/wall/bay/r_wall/steel,
 /area/maintenance/stellardelight/deck2/starboardsolars)
-"Em" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/engineering/atmos/monitoring)
 "En" = (
 /obj/structure/cable/blue{
 	icon_state = "2-4"
@@ -14851,17 +14896,17 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
 "Gz" = (
-/obj/machinery/computer/general_air_control{
-	frequency = 1443;
-	level = 3;
-	name = "Distribution and Waste Monitor";
-	sensors = list("dist_main_meter" = "Surface - Distribution Loop", "scrub_main_meter" = "Surface - Scrubbers Loop", "mair_main_meter" = "Surface - Mixed Air Tank", "dist_aux_meter" = "Station - Distribution Loop", "scrub_aux_meter" = "Station - Scrubbers Loop", "mair_aux_meter" = "Station - Mixed Air Tank", "mair_mining_meter" = "Mining Outpost - Mixed Air Tank")
-	},
 /obj/machinery/power/apc/angled{
 	dir = 1
 	},
 /obj/structure/cable/orange{
 	icon_state = "0-2"
+	},
+/obj/machinery/computer/general_air_control{
+	frequency = 1443;
+	level = 3;
+	name = "Atmospheric Storage Monitor";
+	sensors = list("dist_main_meter"="Distribution Loop","scrub_main_meter"="Scrubbers Loop","mair_main_meter"="Mixed Air Tank","dist_aux_meter"="Mixed Air to Aux","n2_tank"="Nitrogen Reserves","o2_tank"="Oxygen Reserves","no2_tank"="Nitrous Oxide Reserves","phoron_tank"="Phoron Reserves","co2_tank"="Carbon Dioxide Reserves","engine_fuel"="Engine Fuel")
 	},
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/engineering/engineering_monitoring)
@@ -15517,7 +15562,11 @@
 /area/crew_quarters/locker)
 "HX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "mair_main_meter";
+	name = "Mixed Air Storage"
+	},
 /obj/structure/cable/orange{
 	icon_state = "2-4"
 	},
@@ -16189,7 +16238,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "engine_fuel";
+	name = "Engine Fuel meter"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/stellardelight/deck2/fuelstorage)
 "Jt" = (
@@ -22666,6 +22719,7 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/monitoring)
 "XT" = (
@@ -22990,7 +23044,11 @@
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/crew_quarters/bar)
 "YE" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "scrub_main_meter";
+	name = "Waste In Scrubbers"
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 4
 	},
@@ -23398,11 +23456,15 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/cmostore)
 "Zx" = (
-/obj/item/modular_computer/console/preset/engineering{
-	dir = 8
-	},
 /obj/effect/floor_decal/milspec/color/orange/half{
 	dir = 10
+	},
+/obj/machinery/computer/general_air_control{
+	dir = 8;
+	frequency = 1443;
+	level = 3;
+	name = "Atmospheric Storage Monitor";
+	sensors = list("dist_main_meter"="Distribution Loop","scrub_main_meter"="Scrubbers Loop","mair_main_meter"="Mixed Air Tank","dist_aux_meter"="Mixed Air to Aux","n2_tank"="Nitrogen Reserves","o2_tank"="Oxygen Reserves","no2_tank"="Nitrous Oxide Reserves","phoron_tank"="Phoron Reserves","co2_tank"="Carbon Dioxide Reserves","engine_fuel"="Engine Fuel")
 	},
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/bridge)
@@ -30005,8 +30067,8 @@ eq
 eq
 be
 ZT
-Hm
-Em
+jR
+Am
 Am
 Et
 Am
@@ -30426,7 +30488,7 @@ JS
 mB
 eq
 ny
-xu
+ze
 oA
 oo
 Er
@@ -30564,7 +30626,7 @@ xu
 oA
 oo
 xW
-xu
+ju
 oA
 mA
 kW
@@ -31270,11 +31332,11 @@ Es
 te
 eq
 Mu
-xu
+tY
 oA
 TA
 sU
-xu
+zg
 oA
 NX
 xl


### PR DESCRIPTION
They've been renamed to "Atmospheric Storage Monitor" on SD 

Bridge Engineering camera monitor has been replaced with one, the central command computer has access to all cameras anyway.

One has been placed where a wall and poster used to be, next to the atmospheric alarm computer is for easier monitoring.
![04c71cc57e99878ee7415fbe8afa60f8](https://github.com/TS-Rogue-Star/Rogue-Star/assets/6293118/60952e34-66e5-41dd-9f92-89bd77df835c)


For future mapping:

* Sensors must be on the mapped in frequency of the computer (1443 is this one for SD)
* Sensors must have an id tag "dist_main_meter" (with quotes)
* Sensors list in mapper must be a list, e.g.
```
sensors = list(
"dist_main_meter"="Distribution Loop",
"scrub_main_meter"="Scrubbers Loop",
"mair_main_meter"="Mixed Air Tank",
"dist_aux_meter"="Mixed Air to Aux",
"n2_tank"="Nitrogen Reserves",
"o2_tank"="Oxygen Reserves",
"no2_tank"="Nitrous Oxide Reserves",
"phoron_tank"="Phoron Reserves",
"co2_tank"="Carbon Dioxide Reserves",
"engine_fuel"="Engine Fuel")
```

meters/ gas sensors should be something like:
/obj/machinery/meter{
	frequency = 1443;
	id = "engine_fuel";
	name = "Engine Fuel meter"
	},