### PR TITLE
New Vore Prefs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_rs.dm
+++ b/code/modules/mob/living/carbon/human/human_rs.dm
@@ -8,6 +8,8 @@
 	var/vore_sprite_color = list("stomach" = "#FFFFFF", "taur belly" = "#FFFFFF")
 	var/vore_sprite_multiply = list("stomach" = TRUE, "taur belly" = TRUE)
 	var/vore_fullness = 0
+	var/allow_contaminate = TRUE
+	var/allow_stripping = TRUE
 
 /mob/living/carbon/human/proc/update_fullness()
 	var/list/new_fullness = list()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -50,6 +50,15 @@
 
 	ssd_vore = client.prefs_vr.ssd_vore	//RS ADD
 
+
+/mob/living/carbon/human/login_prefs()	//RS ADD START
+	. = ..()
+
+	allow_contaminate = client.prefs_vr.allow_contaminate
+	allow_stripping = client.prefs_vr.allow_stripping
+
+	//RS ADD END
+
 /mob/living/simple_mob/proc/set_name()
 	set name = "Set Name"
 	set desc = "Sets your mobs name. You only get to do this once."
@@ -89,11 +98,32 @@
 /mob/living/simple_mob/animal/giant_spider/carrier //or the ones who fart babies when they die
 	ic_revivable = FALSE
 
+//RS ADD START
 /mob/living/verb/toggle_ssd_vore()
-	set name = "Toggle SSD Vore"
+	set name = "Vore: Toggle SSD Vore"
 	set desc = "Toggles whether or not you can be eaten while SSD."
 	set category = "Preferences"
 
 	client.prefs_vr.ssd_vore = !client.prefs_vr.ssd_vore
 	ssd_vore = client.prefs_vr.ssd_vore
 	to_chat(src, "<span class='notice'>SSD Vore is now [ssd_vore ? "<font color='green'>enabled</font>" : "<font color='red'>disabled</font>"].</span>")
+
+/mob/living/carbon/human/verb/toggle_stripping()
+	set name = "Vore: Toggle Stripping"
+	set desc = "Toggles whether or not bellies can strip your clothes off of you."
+	set category = "Preferences"
+
+	client.prefs_vr.allow_stripping = !client.prefs_vr.allow_stripping
+	allow_stripping = client.prefs_vr.allow_stripping
+	to_chat(src, "<span class='notice'>Stripping is now [allow_stripping ? "<font color='green'>allowed</font>" : "<font color='red'>disallowed</font>"].</span>")
+
+/mob/living/carbon/human/verb/toggle_contaminate()
+	set name = "Vore: Toggle Contaminate"
+	set desc = "Toggles whether or not bellies can contaminate or digest items you are presentl wearing."
+	set category = "Preferences"
+
+	client.prefs_vr.allow_contaminate = !client.prefs_vr.allow_contaminate
+	allow_contaminate = client.prefs_vr.allow_contaminate
+	to_chat(src, "<span class='notice'>Contamination is now [allow_contaminate ? "<font color='green'>allowed</font>" : "<font color='red'>disallowed</font>"].</span>")
+
+//RS ADD END

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1114,6 +1114,10 @@
 	dispvoreprefs += "<b>Leaves Remains:</b> [digest_leave_remains ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"
 	dispvoreprefs += "<b>Mob Vore:</b> [allowmobvore ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"
 	dispvoreprefs += "<b>Selective Mode Pref:</b> [src.selective_preference]<br>"
+	if(ishuman(src))	//RS ADD START
+		var/mob/living/carbon/human/H = src
+		dispvoreprefs += "<b>Stripping:</b> [H.allow_stripping ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"
+		dispvoreprefs += "<b>Contamination:</b> [H.allow_contaminate ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"	//RS ADD END
 	dispvoreprefs += "<u><b>-SPONTANEOUS PREFERENCES-</b></u><br>"
 	dispvoreprefs += "<b>Spontaneous vore prey:</b> [can_be_drop_prey ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"
 	dispvoreprefs += "<b>Spontaneous vore pred:</b> [can_be_drop_pred ? "<font color='green'>Enabled</font>" : "<font color='red'>Disabled</font>"]<br>"

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -73,6 +73,8 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	var/pickup_pref = TRUE
 
 	var/vore_sprite_color = list("stomach" = "#000", "taur belly" = "#000") // RS edit
+	var/allow_contaminate = TRUE	//RS EDIT
+	var/allow_stripping = TRUE		//RS EDIT
 
 	var/list/belly_prefs = list()
 	var/vore_taste = "nothing in particular"
@@ -203,6 +205,8 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	eating_privacy_global = json_from_file["eating_privacy_global"]
 	vore_sprite_color = json_from_file["vore_sprite_color"] // RS edit
 	ssd_vore = json_from_file["ssd_vore"] // RS edit
+	allow_contaminate = json_from_file["allow_contaminate"] // RS edit
+	allow_stripping = json_from_file["allow_stripping"] // RS edit
 
 	//Quick sanitize
 	if(isnull(digestable))
@@ -292,6 +296,10 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 		vore_sprite_color = list("stomach" = "#000", "taur belly" = "#000") //RS edit
 	if(isnull(ssd_vore))	//RS ADD
 		ssd_vore = FALSE	//RS ADD
+	if(isnull(allow_contaminate))	//RS ADD
+		allow_contaminate = TRUE	//RS ADD
+	if(isnull(allow_stripping))	//RS ADD
+		allow_stripping = TRUE	//RS ADD
 
 	return TRUE
 
@@ -333,7 +341,10 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 			"weight_messages"			= weight_messages,
 			"eating_privacy_global"		= eating_privacy_global,
 			"vore_sprite_color"		= vore_sprite_color, //RS edit
-			"ssd_vore"				= ssd_vore	//RS ADD
+			"ssd_vore"				= ssd_vore,	//RS ADD
+			"allow_contaminate" 	= allow_contaminate, // RS edit
+			"allow_stripping" 		= allow_stripping // RS edit
+
 		)
 
 	//List to JSON


### PR DESCRIPTION
Add preferences for contaminate and stripping.

These preferences control whether or not a predator's belly is allowed to strip, contaminate, or digest any items you are presently wearing.

As an important note, these preferences DO NOT protect your equipment once it leaves your mob. If someone strips your gear then it will resume being affected by the belly as normal.

As a note, to digest items that someone is wearing, they need to have contaminates AND stripping enabled, since that option technically does both of those things.

These preferences both start enabled, in order to preserve the existing functionality.

At present, these preferences are accessed via verbs in the preferences tab. Eventually they will likely be applied to the vore panel.
