### PR TITLE
Update rp-z3.dmm

### DIFF
--- a/maps/groundbase/rp-z3.dmm
+++ b/maps/groundbase/rp-z3.dmm
@@ -3367,6 +3367,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/groundbase/hotspring)
+"MS" = (
+/obj/effect/shuttle_landmark/premade/groundbase{
+	name = "Rascal's Pass Shuttlepad"
+	},
+/turf/simulated/floor/reinforced{
+	edge_blending_priority = -1;
+	outdoors = 1
+	},
+/area/groundbase/level3/ne)
 "Na" = (
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/outdoors/sidewalk/slab,
@@ -18129,7 +18138,7 @@ mS
 mS
 mS
 mS
-mS
+MS
 mS
 mS
 mS


### PR DESCRIPTION
### Description:
Talon shuttle and evacuation pod will now be able to land on the surface of Rascal Pass in a special area

### What happened before:
Can't land on Rascall Pass

### What's now:
![image](https://github.com/TS-Rogue-Star/Rogue-Star/assets/74739991/8cbb67da-32f1-4dff-9600-5fbacd7ec439)
![image](https://github.com/TS-Rogue-Star/Rogue-Star/assets/74739991/d86d38fc-4b21-40eb-ab25-d53f5f82edb7)
