### PR TITLE
Cargo blacklists overmap ships

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -58,6 +58,8 @@ SUBSYSTEM_DEF(supply)
 		return 1										//VOREStation Addition: Translocator beacons
 	if(istype(A,/obj/machinery/power/quantumpad)) //	//VOREStation Add: Quantum pads
 		return 1					//VOREStation Add: Quantum pads
+	if(istype(A,/obj/effect/overmap/visitable/ship)) //Rogue Star add: Snowglobe shenanigans
+		return 1
 
 	for(var/atom/B in A.contents)
 		if(.(B))


### PR DESCRIPTION
Turns out doing this breaks many things. So make sure this doesn't happen.

Note: Untested webedit