### PR TITLE
RPV2 Tweaks

### DIFF
--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -174,8 +174,9 @@
 		/area/groundbase/engineering/solarshed,
 		/area/groundbase/engineering/solarfield,
 		/area/groundbase/hotspring,
-		/area/groundbase/hotspring/water
-
+		/area/groundbase/hotspring/water,
+		/area/groundbase/medical/geneticslab,
+		/area/groundbase/engineering/pumpingstation
 		)
 
 	unit_test_exempt_from_atmos = list()

--- a/maps/groundbase/rp-z2.dmm
+++ b/maps/groundbase/rp-z2.dmm
@@ -3424,7 +3424,6 @@
 /turf/simulated/shuttle/wall,
 /area/shuttle/groundbase/engineering)
 "lh" = (
-/obj/machinery/computer/transhuman/designer,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 4
@@ -3432,6 +3431,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
+/obj/machinery/medical_kiosk,
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/lobby)
 "li" = (
@@ -4848,6 +4848,15 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/groundbase/security/hall2)
+"qj" = (
+/obj/structure/railing,
+/obj/structure/bed/chair/backed_red{
+	dir = 8
+	},
+/turf/simulated/floor/bmarble{
+	outdoors = 1
+	},
+/area/groundbase/civilian/bar)
 "ql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -9202,7 +9211,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/medical_kiosk,
+/obj/machinery/computer/transhuman/designer{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/lobby)
 "Fg" = (
@@ -22582,7 +22593,7 @@ rB
 mQ
 BE
 dF
-ai
+qj
 Wf
 TH
 TH


### PR DESCRIPTION
Adds a couple new areas to exempt from unit tests, and swaps the positions of a couple medical lobby consoles
