### PR TITLE
Removes ability for research cyborgs to self-upgrade.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -707,6 +707,8 @@
 				update_icon()
 			else
 				to_chat(user, "<span class='filter_notice'><font color='red'>Access denied.</font></span>")
+				if(user == src) //RS edit: No self-unlocking.
+					to_chat(user, "<span class='filter_notice'>You are not allowed to manipulate your own lock.</span>")
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
@@ -714,6 +716,8 @@
 			to_chat(usr, "<span class='filter_notice'>You must access the borgs internals!</span>")
 		else if(!src.module && U.require_module)
 			to_chat(usr, "<span class='filter_notice'>The borg must choose a module before it can be upgraded!</span>")
+		else if(user == src) //RS edit: No self-unlocking.
+			to_chat(user, "<span class='warning'>You lack the reach to be able to upgrade yourself.</span>")
 		else if(U.locked)
 			to_chat(usr, "<span class='filter_notice'>The upgrade is locked and cannot be used yet!</span>")
 		else
@@ -846,7 +850,10 @@
 	else if(istype(M, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/weapon/card/robot))
-			return 1
+			if(R == src) //RS edit: No self-unlocking.
+				return 0
+			else
+				return 1
 	return 0
 
 /mob/living/silicon/robot/proc/check_access(obj/item/I)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -716,7 +716,7 @@
 			to_chat(usr, "<span class='filter_notice'>You must access the borgs internals!</span>")
 		else if(!src.module && U.require_module)
 			to_chat(usr, "<span class='filter_notice'>The borg must choose a module before it can be upgraded!</span>")
-		else if(user == src) //RS edit: No self-unlocking.
+		else if(user == src) //RS edit: No self-upgrading.
 			to_chat(user, "<span class='warning'>You lack the reach to be able to upgrade yourself.</span>")
 		else if(U.locked)
 			to_chat(usr, "<span class='filter_notice'>The upgrade is locked and cannot be used yet!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -851,9 +851,9 @@
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/weapon/card/robot))
 			if(R == src) //RS edit: No self-unlocking.
-				return 0
+				return FALSE
 			else
-				return 1
+				return TRUE
 	return 0
 
 /mob/living/silicon/robot/proc/check_access(obj/item/I)


### PR DESCRIPTION
Did you know that research cyborgs can trivially shove a reset board into themselves and become any other module on the fly? Let's nip that in the bud.
Self-repairing is disallowed, after all, self-upgrading is all too similar.

Also disallows self-unlocking because you know they'll just resort to dragging around a crate of upgrades and telling the first assistant they find to bonk it with them.

Does **not** prevent research cyborgs from unlocking and upgrading others.