### PR TITLE
Bone related

### DIFF
--- a/code/modules/vore/eating/leave_remains_vr.dm
+++ b/code/modules/vore/eating/leave_remains_vr.dm
@@ -130,22 +130,22 @@
 		RegisterSignal(pred, COMSIG_PARENT_QDELETING, PROC_REF(destroy_self_woah), TRUE)
 
 /obj/item/weapon/digestion_remains/proc/on_pred_move()
-	if(isturf(loc))
+	if(isturf(loc))		//Only think about stuff if we're on the floor
 		var/delet = FALSE
-		if(pred.x > x + 7)
+		if(pred.x > x + 7)	//Right
 			delet = TRUE
-		else if(pred.x < x - 7)
+		else if(pred.x < x - 7)	//Left
 			delet = TRUE
-		else if(pred.y > y + 7)
+		else if(pred.y > y + 7)	//North
 			delet = TRUE
-		else if(pred.y < y - 7)
+		else if(pred.y < y - 7)	//South
 			delet = TRUE
 
 		var/turf/ourturf = loc
 
-		if(delet)
-			if(ourturf.get_lumcount() > 0.25)
-				destroy_self_woah()
+		if(delet)	//Only think about the lighting if everything else clears
+			if(ourturf.get_lumcount() > 0.25)	//0 is dark, 1 is pure light
+				destroy_self_woah()		//RIP
 
 /obj/item/weapon/digestion_remains/proc/destroy_self_woah()
 	UnregisterSignal(pred, COMSIG_MOVABLE_MOVED)

--- a/code/modules/vore/eating/leave_remains_vr.dm
+++ b/code/modules/vore/eating/leave_remains_vr.dm
@@ -141,8 +141,11 @@
 		else if(pred.y < y - 7)
 			delet = TRUE
 
+		var/turf/ourturf = loc
+
 		if(delet)
-			destroy_self_woah()
+			if(ourturf.get_lumcount() > 0.25)
+				destroy_self_woah()
 
 /obj/item/weapon/digestion_remains/proc/destroy_self_woah()
 	UnregisterSignal(pred, COMSIG_MOVABLE_MOVED)

--- a/code/modules/vore/eating/leave_remains_vr.dm
+++ b/code/modules/vore/eating/leave_remains_vr.dm
@@ -119,6 +119,16 @@
 			RegisterSignal(pred, COMSIG_MOVABLE_MOVED, PROC_REF(on_pred_move))
 			RegisterSignal(pred, COMSIG_PARENT_QDELETING, PROC_REF(destroy_self_woah), TRUE)
 
+/obj/item/weapon/digestion_remains/pickup(mob/user)
+	. = ..()
+
+	if(pred && user != pred)
+		UnregisterSignal(pred, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(pred, COMSIG_PARENT_QDELETING)
+		pred = user
+		RegisterSignal(pred, COMSIG_MOVABLE_MOVED, PROC_REF(on_pred_move))
+		RegisterSignal(pred, COMSIG_PARENT_QDELETING, PROC_REF(destroy_self_woah), TRUE)
+
 /obj/item/weapon/digestion_remains/proc/on_pred_move()
 	if(isturf(loc))
 		var/delet = FALSE


### PR DESCRIPTION
An idea for a problem - Requires discussion with staff

When a bone is generated via digestion, it registers the predator to a variable, and begins listening to the signal for the predator's movement proc, and destroy proc.

When the predator moves, if the bone is left on a turf, and if the predator is more than 7 turfs away from the bone on x or y, and also in less than 25% light, then the bone will delete itself. The bone will not delete itself unless it is on a turf.

Additionally, makes bones delete themselves when you are deleted. This way if you cryo, all of the bones registered to you, no matter where they are, will be removed. There isn't really a difference between cryoing and other methods of being deleted, so, things like digestion and gibbing will also result in the bones being deleted, but there's not a whole lot I can do about that.

If a bone is picked up by someone, the bone will become bonded to the new person who picked it up, so it will then only delete itself if the new person moves out of range of it, or is deleted as described above.

Right now the bones just instantly disappear. Maybe we can make them display a message and fade out or turn into ash instead if just instantly disappearing.

The idea behind this is to have mechanics better represent the intended use case for these mechanics, and hopefully resolve a long standing issue with the digestion remains mechanic. Some people like it, some people can't stand it. Rather than making convoluted and difficult to define and follow rules about how the mechanic can be used, I am seeking a mechanical solution to the problem.

The intention for these bones is, that you can have them around you, you can hide them away somewhere, you can give them to people. You should not leave them out in the open somewhere for others to find.
