### PR TITLE
Fixes "electronic device", and makes available from circuit printer.

### DIFF
--- a/code/controllers/subsystems/circuits.dm
+++ b/code/controllers/subsystems/circuits.dm
@@ -84,7 +84,8 @@ SUBSYSTEM_DEF(circuit)
 		/obj/item/clothing/shoes/circuitry,
 		/obj/item/clothing/head/circuitry,
 		/obj/item/clothing/ears/circuitry,
-		/obj/item/clothing/suit/circuitry
+		/obj/item/clothing/suit/circuitry,
+		/obj/item/device/assembly/electronic_assembly
 		)
 
 	circuit_fabricator_recipe_list["Tools"] = list(

--- a/code/modules/integrated_electronics/core/assemblies/device.dm
+++ b/code/modules/integrated_electronics/core/assemblies/device.dm
@@ -48,8 +48,7 @@
 /obj/item/device/assembly/electronic_assembly/examine(mob/user)
 	. = ..()
 	if(EA)
-		for(var/obj/item/integrated_circuit/IC in EA.contents)
-			. += IC.external_examine(user)
+		. += EA.examine(user)
 
 /obj/item/device/assembly/electronic_assembly/verb/toggle()
 	set src in usr
@@ -77,8 +76,5 @@
 	input.assembly = src
 	output.assembly = src
 
-/obj/item/device/electronic_assembly/device/check_interactivity(mob/user)
-	if(!CanInteract(user, state = GLOB.tgui_deep_inventory_state))
-		return 0
-	return 1
-
+/obj/item/device/electronic_assembly/device/tgui_host()
+	return holder.tgui_host()

--- a/code/modules/integrated_electronics/core/assemblies/device.dm
+++ b/code/modules/integrated_electronics/core/assemblies/device.dm
@@ -76,5 +76,10 @@
 	input.assembly = src
 	output.assembly = src
 
+/obj/item/device/electronic_assembly/device/check_interactivity(mob/user)
+	if(!CanInteract(user, state = GLOB.tgui_deep_inventory_state))
+		return 0
+	return 1
+
 /obj/item/device/electronic_assembly/device/tgui_host()
 	return holder.tgui_host()


### PR DESCRIPTION
To explain, the "electronic device" is an integrated circuit assembly that is able to be attached to other assembly devices (Such as igniters, timers, signalers, TTVs, proximity sensor, ... mousetraps, etc etc), and send and recieve outputs with them. Available from the protolathe and the (old, crappy, mostly-removed) circuit kits, they didn't work because it was impossible to open their interface and work with any circuits set inside of them.

This PR fixes that, and makes them available from the handheld circuit printer.