### PR TITLE
Enhances admin spawn atom verb

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -41,6 +41,9 @@
 
 #define R_MAXPERMISSION 0x8000 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
+//How many things you can spawn at once with spawn verb/create panel
+#define ADMIN_SPAWN_CAP 100
+
 #define SMITE_BREAKLEGS				"Break Legs"
 #define SMITE_BLUESPACEARTILLERY	"Bluespace Artillery"
 #define SMITE_SPONTANEOUSCOMBUSTION	"Spontaneous Combustion"

--- a/code/_helpers/_lists.dm
+++ b/code/_helpers/_lists.dm
@@ -171,6 +171,62 @@
 						L[T] = TRUE
 		return L
 
+/**
+ * Like typesof() or subtypesof(), but returns a typecache instead of a list.
+ * This time it also uses the associated values given by the input list for the values of the subtypes.
+ *
+ * Latter values from the input list override earlier values.
+ * Thus subtypes should come _after_ parent types in the input list.
+ * Notice that this is the opposite priority of [/proc/is_type_in_list] and [/proc/is_path_in_list].
+ *
+ * Arguments:
+ * - path: A typepath or list of typepaths with associated values.
+ * - single_value: The assoc value used if only a single path is passed as the first variable.
+ * - only_root_path: Whether the typecache should be specifically of the passed types.
+ * - ignore_root_path: Whether to ignore the root path when caching subtypes.
+ * - clear_nulls: Whether to remove keys with null assoc values from the typecache after generating it.
+ */
+/proc/zebra_typecacheof(path, single_value = TRUE, only_root_path = FALSE, ignore_root_path = FALSE, clear_nulls = FALSE)
+	if(isnull(path))
+		return
+
+	if(ispath(path))
+		if (isnull(single_value))
+			return
+
+		. = list()
+		if(only_root_path)
+			.[path] = single_value
+			return
+
+		for(var/subtype in (ignore_root_path ? subtypesof(path) : typesof(path)))
+			.[subtype] = single_value
+		return
+
+	if(!islist(path))
+		CRASH("Tried to create a typecache of [path] which is neither a typepath nor a list.")
+
+	. = list()
+	var/list/pathlist = path
+	if(only_root_path)
+		for(var/current_path in pathlist)
+			.[current_path] = pathlist[current_path]
+	else if(ignore_root_path)
+		for(var/current_path in pathlist)
+			for(var/subtype in subtypesof(current_path))
+				.[subtype] = pathlist[current_path]
+	else
+		for(var/current_path in pathlist)
+			for(var/subpath in typesof(current_path))
+				.[subpath] = pathlist[current_path]
+
+	if(!clear_nulls)
+		return
+
+	for(var/cached_path in .)
+		if (isnull(.[cached_path]))
+			. -= cached_path
+
 //////////////////////////////////////////////////////
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected

--- a/code/_helpers/type_processing.dm
+++ b/code/_helpers/type_processing.dm
@@ -1,0 +1,210 @@
+/proc/make_types_fancy(list/types)
+	if (ispath(types))
+		types = list(types)
+	var/static/list/types_to_replacement
+	var/static/list/replacement_to_text
+	if(!types_to_replacement)
+		// Longer paths come after shorter ones, try and keep the structure
+		var/list/work_from = list(
+			/datum = "DATUM",
+			/datum/reagent = "REAGENT",
+
+			/area = "AREA",
+			/area/redgate = "AREA_REDGATE",
+
+			/atom/movable = "MOVABLE",
+			/obj = "OBJ",
+			/turf = "TURF",
+			/turf/space = "SPACE",
+			/turf/simulated = "SIMULATED",
+			/turf/unsimulated = "UNSIMULATED",
+			/turf/simulated/floor = "FLOOR",
+			/turf/simulated/floor/dungeon = "DUNGEON_FLOOR",
+			/turf/simulated/floor/outdoors = "OUTDOOR_FLOOR",
+			/turf/simulated/floor/outdoors/snow = "OUTDOOR_SNOW",
+			/turf/simulated/floor/outdoors/grass = "OUTDOOR_GRASS",
+			/turf/simulated/floor/water = "WATER",
+			/turf/simulated/floor/water/underwater = "UNDERWATER",
+			/turf/simulated/floor/lava = "LAVA",
+			/turf/simulated/shuttle = "SHUTTLE",
+			/turf/simulated/wall = "WALL",
+			/turf/simulated/wall/dungeon = "DUNGEON_WALL",
+			/turf/simulated/wall/solidrock = "SOLID_ROCK",
+			/turf/simulated/wall/eris = "ERIS_WALL",
+			/turf/simulated/wall/bay = "BAY_WALL",
+			/turf/simulated/wall/tgmc = "TGMC_WALL",
+			/turf/simulated/flesh = "FLESH",
+
+
+			/mob = "MOB",
+			/mob/living = "LIVING",
+			/mob/living/carbon = "CARBON",
+			/mob/living/carbon/human = "HUMANOID",
+			/mob/living/simple_mob = "SIMPLE",
+			/mob/living/simple_mob/vore = "SIMPLE_VORE",
+			/mob/living/simple_mob/vore/alienanimals = "SIMPLE_VORE_ALIENS",
+			/mob/living/simple_mob/humanoid = "SIMPLE_HUMAN",
+			/mob/living/simple_mob/animal = "SIMPLE_ANIMAL",
+			/mob/living/simple_mob/animal/passive = "SIMPLE_PASSIVE",
+			/mob/living/simple_mob/animal/giant_spider = "GIANT_SPIDER",
+			/mob/living/simple_mob/animal/space = "SIMPLE_SPACE",
+			/mob/living/simple_mob/animal/space/carp = "CARP",
+			/mob/living/simple_mob/animal/space/goose = "GOOSE",
+			/mob/living/simple_mob/animal/space/alien = "SPACE_ALIEN",
+			/mob/living/silicon = "SILICON",
+			/mob/living/silicon/robot = "CYBORG",
+
+			/obj/item = "ITEM",
+			/obj/item/weapon = "WEAPON",
+			/obj/item/weapon/cell = "POWERCELL",
+			/obj/item/mecha_parts = "MECHA_PART",
+			/obj/item/mecha_parts/mecha_equipment = "MECHA_EQUIP",
+			/obj/item/mecha_parts/mecha_equipment/weapon = "MECHA_WEAPON",
+			/obj/item/weapon/card = "CARD",
+			/obj/item/weapon/card/id = "IDCARD",
+			/obj/item/weapon/tool = "TOOL",
+			/obj/item/weapon/surgical = "SURGICAL",
+			/obj/item/weapon/melee = "MELEE",
+			/obj/item/weapon/melee/energy = "ENERGY_MELEE",
+			/obj/item/weapon/gun = "GUN",
+			/obj/item/weapon/gun/launcher = "GUN_LAUNCHER",
+			/obj/item/weapon/gun/magic = "GUN_MAGIC",
+			/obj/item/weapon/gun/energy = "GUN_ENERGY",
+			/obj/item/weapon/gun/energy/laser = "GUN_LASER",
+			/obj/item/weapon/gun/magnetic = "GUN_MAGNETIC",
+			/obj/item/weapon/gun/projectile = "GUN_BALLISTIC",
+			/obj/item/weapon/gun/projectile/automatic = "GUN_AUTOMATIC",
+			/obj/item/weapon/gun/projectile/revolver = "GUN_REVOLVER",
+			//obj/item/weapon/gun/projectile/rifle = "GUN_RIFLE",
+			/obj/item/weapon/gun/projectile/shotgun = "GUN_SHOTGUN",
+			/obj/item/stack = "STACK",
+			/obj/item/stack/material = "SHEET",
+			//obj/item/stack/sheet/mineral = "MINERAL_SHEET",
+			/obj/item/weapon/ore = "ORE",
+			/obj/item/stack/medical = "STACK_MED",
+			/obj/item/weapon/aiModule = "AI_LAW_MODULE",
+			/obj/item/weapon/circuitboard = "CIRCUITBOARD",
+			//obj/item/weapon/circuitboard/machine = "MACHINE_BOARD",
+			//obj/item/weapon/circuitboard/computer = "COMPUTER_BOARD",
+			/obj/item/weapon/reagent_containers = "REAGENT_CONTAINERS",
+			/obj/item/weapon/reagent_containers/glass = "GLASS",
+			/obj/item/weapon/reagent_containers/glass/bottle = "BOTTLE",
+			/obj/item/weapon/reagent_containers/glass/bottle/hypovial = "HYPOVIAL",
+			/obj/item/weapon/reagent_containers/pill = "PILL",
+			/obj/item/weapon/reagent_containers/pill/patch = "MEDPATCH",
+			/obj/item/weapon/reagent_containers/hypospray/autoinjector = "AUTOINJECT",
+			/obj/item/weapon/reagent_containers/food = "FOOD",
+			/obj/item/weapon/reagent_containers/food/snacks = "SNACKS",
+			/obj/item/weapon/reagent_containers/food/drinks = "DRINK",
+			/obj/item/organ = "ORGAN",
+			/obj/item/organ/external = "ORGAN_EXT",
+			/obj/item/organ/internal = "ORGAN_INT",
+			/obj/effect/decal/cleanable = "CLEANABLE",
+			/obj/item/device = "DEVICE",
+			/obj/item/device/nif = "NIF",
+			/obj/item/device/radio = "RADIO",
+			/obj/item/device/radio/headset = "HEADSET",
+			/obj/item/clothing = "CLOTHING",
+			/obj/item/clothing/accessory = "ACCESSORY",
+			/obj/item/clothing/mask/gas = "GASMASK",
+			/obj/item/clothing/mask = "MASK",
+			/obj/item/clothing/gloves = "GLOVES",
+			/obj/item/clothing/shoes = "SHOES",
+			/obj/item/clothing/under = "JUMPSUIT",
+			/obj/item/clothing/suit/armor = "ARMOR",
+			/obj/item/clothing/suit = "SUIT",
+			/obj/item/clothing/head/helmet = "HELMET",
+			/obj/item/clothing/head = "HEAD",
+			//obj/item/clothing/neck = "NECK",
+			/obj/item/weapon/storage = "STORAGE",
+			/obj/item/weapon/storage/box = "STORAGE_BOX",
+			/obj/item/weapon/storage/box/fluff = "STORAGE_FLUFF",
+			/obj/item/weapon/storage/firstaid = "FIRSTAID_BOX",
+			/obj/item/weapon/storage/firstaid/hypokit = "HYPOKIT",
+			/obj/item/weapon/storage/backpack = "BACKPACK",
+			/obj/item/weapon/storage/belt = "BELT",
+			/obj/item/weapon/storage/pill_bottle = "PILL_BOTTLE",
+			/obj/item/weapon/storage/toolbox = "TOOLBOX",
+			/obj/item/weapon/book/manual = "MANUAL",
+
+			/obj/structure = "STRUCTURE",
+			/obj/structure/closet = "CLOSET",
+			/obj/structure/closet/crate = "CRATE",
+			/obj/structure/closet/crate/secure = "LOCKED_CRATE",
+			/obj/structure/closet/secure_closet = "LOCKED_CLOSET",
+			/obj/structure/largecrate = "LARGE_CRATE",
+			/obj/structure/low_wall = "LOW_WALL",
+			/obj/structure/low_wall/bay = "LOW_BAY_WALL",
+			/obj/structure/low_wall/eris = "LOW_ERIS_WALL",
+			/obj/structure/hull_corner = "HULL_CORNER",
+			/obj/structure/grille = "GRILLE",
+			/obj/structure/grille/bay = "GRILLE_BAY",
+			/obj/structure/window = "WINDOW",
+			/obj/structure/window/bay = "WINDOW_BAY",
+			/obj/structure/window/eris = "WINDOW_ERIS",
+			/obj/structure/bed = "BED",
+			/obj/structure/bed/chair = "CHAIR",
+			/obj/structure/bed/chair/sofa = "SOFA",
+			/obj/structure/bed/chair/office = "CHAIR_OFFICE",
+			/obj/structure/flora = "FLORA",
+			/obj/structure/prop = "PROP",
+
+			/obj/machinery = "MACHINERY",
+			/obj/machinery/atmospherics = "ATMOS_MECH",
+			/obj/machinery/portable_atmospherics = "PORT_ATMOS",
+			/obj/machinery/door = "DOOR",
+			/obj/machinery/door/airlock = "AIRLOCK",
+			//obj/machinery/rnd/production = "RND_FABRICATOR",
+			/obj/machinery/computer = "COMPUTER",
+			//obj/machinery/computer/camera_advanced/shuttle_docker = "DOCKING_COMPUTER",
+			/obj/machinery/vending = "VENDING",
+			/obj/machinery/vending/wardrobe = "JOBDROBE",
+			/obj/effect = "EFFECT",
+			/obj/item/projectile = "PROJECTILE",
+		)
+		// ignore_root_path so we can draw the root normally
+		types_to_replacement = zebra_typecacheof(work_from, ignore_root_path = TRUE)
+		replacement_to_text = list()
+		for(var/key in work_from)
+			replacement_to_text[work_from[key]] = "[key]"
+
+	. = list()
+	for(var/type in types)
+		var/replace_with = types_to_replacement[type]
+		if(!replace_with)
+			.["[type]"] = type
+			continue
+		var/cut_out = replacement_to_text[replace_with]
+		// + 1 to account for /
+		.[replace_with + copytext("[type]", length(cut_out) + 1)] = type
+
+/proc/get_fancy_list_of_atom_types()
+	var/static/list/pre_generated_list
+	if (!pre_generated_list) //init
+		pre_generated_list = make_types_fancy(typesof(/atom))
+	return pre_generated_list
+
+
+/proc/get_fancy_list_of_datum_types()
+	var/static/list/pre_generated_list
+	if (!pre_generated_list) //init
+		pre_generated_list = make_types_fancy(sortList(typesof(/datum) - typesof(/atom)))
+	return pre_generated_list
+
+
+/proc/filter_fancy_list(list/L, filter as text)
+	var/list/matches = new
+	var/end_len = -1
+	var/list/endcheck = splittext(filter, "!")
+	if(endcheck.len > 1)
+		filter = endcheck[1]
+		end_len = length_char(filter)
+
+	for(var/key in L)
+		var/value = L[key]
+		if(findtext("[key]", filter, -end_len) || findtext("[value]", filter, -end_len))
+			matches[key] = value
+	return matches
+
+/proc/return_typenames(type)
+	return splittext("[type]", "/")

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1428,68 +1428,6 @@ var/mob/dview/dview_mob = new
 	chosen = matches[chosen]
 	return chosen
 
-/proc/get_fancy_list_of_atom_types()
-	var/static/list/pre_generated_list
-	if (!pre_generated_list) //init
-		pre_generated_list = make_types_fancy(typesof(/atom))
-	return pre_generated_list
-
-/proc/get_fancy_list_of_datum_types()
-	var/static/list/pre_generated_list
-	if (!pre_generated_list) //init
-		pre_generated_list = make_types_fancy(sortList(typesof(/datum) - typesof(/atom)))
-	return pre_generated_list
-
-/proc/filter_fancy_list(list/L, filter as text)
-	var/list/matches = new
-	for(var/key in L)
-		var/value = L[key]
-		if(findtext("[key]", filter) || findtext("[value]", filter))
-			matches[key] = value
-	return matches
-
-/proc/make_types_fancy(var/list/types)
-	if (ispath(types))
-		types = list(types)
-	. = list()
-	for(var/type in types)
-		var/typename = "[type]"
-		var/static/list/TYPES_SHORTCUTS = list(
-			/obj/effect/decal/cleanable = "CLEANABLE",
-			/obj/item/device/radio/headset = "HEADSET",
-			/obj/item/clothing/head/helmet/space = "SPESSHELMET",
-			/obj/item/weapon/book/manual = "MANUAL",
-			/obj/item/weapon/reagent_containers/food/drinks = "DRINK",
-			/obj/item/weapon/reagent_containers/food = "FOOD",
-			/obj/item/weapon/reagent_containers = "REAGENT_CONTAINERS",
-			/obj/machinery/atmospherics = "ATMOS_MECH",
-			/obj/machinery/portable_atmospherics = "PORT_ATMOS",
-			/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack = "MECHA_MISSILE_RACK",
-			/obj/item/mecha_parts/mecha_equipment = "MECHA_EQUIP",
-			/obj/item/organ = "ORGAN",
-			/obj/item = "ITEM",
-			/obj/machinery = "MACHINERY",
-			/obj/effect = "EFFECT",
-			/obj = "O",
-			/datum = "D",
-			/turf/simulated/wall = "S-WALL",
-			/turf/simulated/floor = "S-FLOOR",
-			/turf/simulated = "SIMULATED",
-			/turf/unsimulated/wall = "US-WALL",
-			/turf/unsimulated/floor = "US-FLOOR",
-			/turf/unsimulated = "UNSIMULATED",
-			/turf = "T",
-			/mob/living/carbon = "CARBON",
-			/mob/living/simple_mob = "SIMPLE",
-			/mob/living = "LIVING",
-			/mob = "M"
-		)
-		for (var/tn in TYPES_SHORTCUTS)
-			if (copytext(typename,1, length("[tn]/")+1)=="[tn]/" /*findtextEx(typename,"[tn]/",1,2)*/ )
-				typename = TYPES_SHORTCUTS[tn]+copytext(typename,length("[tn]/"))
-				break
-		.[typename] = type
-
 /proc/IsValidSrc(datum/D)
 	if(istype(D))
 		return !QDELETED(D)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1112,33 +1112,29 @@ var/datum/announcement/minor/admin_min_announcer = new
 	set category = "Debug"
 	set desc = "(atom path) Spawn an atom"
 
-	if(!check_rights(R_SPAWN))	return
-
-	var/list/types = typesof(/atom)
-	var/list/matches = new()
-
-	for(var/path in types)
-		if(findtext("[path]", object))
-			matches += path
-
-	if(matches.len==0)
+	if(!check_rights(R_SPAWN) || !object)
 		return
 
-	var/chosen
-	if(matches.len==1)
-		chosen = matches[1]
-	else
-		chosen = tgui_input_list(usr, "Select an atom type", "Spawn Atom", matches)
-		if(!chosen)
-			return
+	var/list/preparsed = splittext(object,":")
+	var/path = preparsed[1]
+	var/amount = 1
+	if(preparsed.len > 1)
+		amount = clamp(text2num(preparsed[2]),1,ADMIN_SPAWN_CAP)
 
-	if(ispath(chosen,/turf))
-		var/turf/T = get_turf(usr.loc)
+	var/chosen = pick_closest_path(path)
+	if(!chosen)
+		return
+	var/turf/T = get_turf(usr)
+
+	if(ispath(chosen, /turf))
 		T.ChangeTurf(chosen)
 	else
-		new chosen(usr.loc)
+		for(var/i in 1 to amount)
+			new chosen(T)
+		//	A.flags_1 |= ADMIN_SPAWNED_1	//ain't got flags, sadly.
 
-	log_and_message_admins("spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
+
+	log_and_message_admins("[key_name(usr)] spawned [amount] x [chosen] at [ADMIN_COORDJMP(usr)]")
 	feedback_add_details("admin_verb","SA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1134,7 +1134,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 		//	A.flags_1 |= ADMIN_SPAWNED_1	//ain't got flags, sadly.
 
 
-	log_and_message_admins("[key_name(usr)] spawned [amount] x [chosen] at [ADMIN_COORDJMP(usr)]")
+	log_and_message_admins("spawned [amount] x [chosen] at [ADMIN_COORDJMP(usr)]")
 	feedback_add_details("admin_verb","SA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1728,7 +1728,7 @@
 			tgui_alert_async(usr, "Removed:\n" + jointext(removed_paths, "\n"))
 
 		var/list/offset = splittext(href_list["offset"],",")
-		var/number = dd_range(1, 100, text2num(href_list["object_count"]))
+		var/number = dd_range(1, ADMIN_SPAWN_CAP, text2num(href_list["object_count"]))
 		var/X = offset.len > 0 ? text2num(offset[1]) : 0
 		var/Y = offset.len > 1 ? text2num(offset[2]) : 0
 		var/Z = offset.len > 2 ? text2num(offset[3]) : 0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -147,6 +147,7 @@
 #include "code\_helpers\time.dm"
 #include "code\_helpers\turfs.dm"
 #include "code\_helpers\type2type.dm"
+#include "code\_helpers\type_processing.dm"
 #include "code\_helpers\unsorted.dm"
 #include "code\_helpers\unsorted_vr.dm"
 #include "code\_helpers\view.dm"


### PR DESCRIPTION
Shortens the paths listed in the spawn atom verb. This was apparently already here but no-one updated the verb to utilize it. So I've fixed that

if you add a : (number) (I.e `Spawn Corgi:50` you will spawn that many items at once. Limit 100.

I do not take any responsibility for incidents this may result in.
![8dd536b7aa7443dfadb2ee6d81f1b7e3](https://github.com/TS-Rogue-Star/Rogue-Star/assets/6293118/1c715050-7524-496f-8ba7-049d19927ad2)
![8992b69132e375243cb177aa806309c2](https://github.com/TS-Rogue-Star/Rogue-Star/assets/6293118/4810fe19-1932-4e2e-8ae4-d7ad3378eb71)
![f886b9ec977a07265d7e0da9017885cb](https://github.com/TS-Rogue-Star/Rogue-Star/assets/6293118/9e0b1e83-a90e-4959-bd03-035d53519f81)
![07de5f7cfc413e883e9aa7729ef27258](https://github.com/TS-Rogue-Star/Rogue-Star/assets/6293118/97797420-6f6d-4309-90db-0125d009293e)
