### PR TITLE
Makes unsimulated planetary turfs much better at changing temperature.

### DIFF
--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -224,9 +224,9 @@ Class Procs:
 		erase()
 		return
 
-	var/is_planet = 0 // RS edit
+	var/is_planet = FALSE // RS edit
 	if(istype(B,/turf/unsimulated/wall/planetary))
-		is_planet = 1
+		is_planet = TRUE
 	var/equiv = A.air.share_space(air, planetary = is_planet)
 
 	var/differential = A.air.return_pressure() - air.return_pressure()

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -224,7 +224,10 @@ Class Procs:
 		erase()
 		return
 
-	var/equiv = A.air.share_space(air)
+	var/is_planet = 0 // RS edit
+	if(istype(B,/turf/unsimulated/wall/planetary))
+		is_planet = 1
+	var/equiv = A.air.share_space(air, planetary = is_planet)
 
 	var/differential = A.air.return_pressure() - air.return_pressure()
 	if(abs(differential) >= vsc.airflow_lightest_pressure)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -394,7 +394,7 @@
 
 
 //Shares gas with another gas_mixture based on the amount of connecting tiles and a fixed lookup table.
-/datum/gas_mixture/proc/share_ratio(datum/gas_mixture/other, connecting_tiles, share_size = null, one_way = 0, planetary = 0)
+/datum/gas_mixture/proc/share_ratio(datum/gas_mixture/other, connecting_tiles, share_size = null, one_way = FALSE, planetary = FALSE)
 	var/static/list/sharing_lookup_table = list(0.30, 0.40, 0.48, 0.54, 0.60, 0.66)
 	//Shares a specific ratio of gas between mixtures using simple weighted averages.
 	var/ratio = sharing_lookup_table[6]
@@ -444,7 +444,7 @@
 
 //A wrapper around share_ratio for spacing gas at the same rate as if it were going into a large airless room.
 /datum/gas_mixture/proc/share_space(datum/gas_mixture/unsim_air, planetary)
-	return share_ratio(unsim_air, unsim_air.group_multiplier, max(1, max(group_multiplier + 3, 1) + unsim_air.group_multiplier), one_way = 1, planetary = planetary)
+	return share_ratio(unsim_air, unsim_air.group_multiplier, max(1, max(group_multiplier + 3, 1) + unsim_air.group_multiplier), one_way = TRUE, planetary = planetary)
 
 
 //Equalizes a list of gas mixtures.  Used for pipe networks.

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -394,7 +394,7 @@
 
 
 //Shares gas with another gas_mixture based on the amount of connecting tiles and a fixed lookup table.
-/datum/gas_mixture/proc/share_ratio(datum/gas_mixture/other, connecting_tiles, share_size = null, one_way = 0)
+/datum/gas_mixture/proc/share_ratio(datum/gas_mixture/other, connecting_tiles, share_size = null, one_way = 0, planetary = 0)
 	var/static/list/sharing_lookup_table = list(0.30, 0.40, 0.48, 0.54, 0.60, 0.66)
 	//Shares a specific ratio of gas between mixtures using simple weighted averages.
 	var/ratio = sharing_lookup_table[6]
@@ -404,6 +404,8 @@
 
 	var/full_heat_capacity = heat_capacity()
 	var/s_full_heat_capacity = other.heat_capacity()
+	if(planetary) // RS edit
+		s_full_heat_capacity = max(s_full_heat_capacity,s_full_heat_capacity * share_size)
 
 	var/list/avg_gas = list()
 
@@ -441,8 +443,8 @@
 
 
 //A wrapper around share_ratio for spacing gas at the same rate as if it were going into a large airless room.
-/datum/gas_mixture/proc/share_space(datum/gas_mixture/unsim_air)
-	return share_ratio(unsim_air, unsim_air.group_multiplier, max(1, max(group_multiplier + 3, 1) + unsim_air.group_multiplier), one_way = 1)
+/datum/gas_mixture/proc/share_space(datum/gas_mixture/unsim_air, planetary)
+	return share_ratio(unsim_air, unsim_air.group_multiplier, max(1, max(group_multiplier + 3, 1) + unsim_air.group_multiplier), one_way = 1, planetary = planetary)
 
 
 //Equalizes a list of gas mixtures.  Used for pipe networks.


### PR DESCRIPTION
This works by giving unsimulated planetary turfs an effective boost to their heat capacity to the same degree that unsimulated turfs have for gas mixture. Specifically done for planetary turfs as to not change current behavior with space turfs.

I do not know for certain how much extra processing this adds, through these checks are only done once per tick for every zone interacting with unsimulated turfs, and only when there's a difference worth processing, so it shouldn't be much.

Rudimentary tests were done with various things such as active supermatters, venting toxins burn chambers to the air, popping canisters with gas mixtures varedited to ridiculous levels, but I feel this warrants a 'hey everyone go out of your way to mess with the atmosphere, go wild' test round on rascal's pass before merging.