### PR TITLE
Pink Slime Heal Balance

### DIFF
--- a/code/modules/mob/_modifiers/aura.dm
+++ b/code/modules/mob/_modifiers/aura.dm
@@ -12,7 +12,7 @@ making it not expire ever, which is likely not what you want.
 		expire()
 	var/atom/A = origin.resolve()
 	if(istype(A)) // Make sure we're not null.
-		if(get_dist(holder, A) > aura_max_distance)
+		if(!(A in view(aura_max_distance, holder)))
 			expire()
 	else
 		expire() // Source got deleted or something.


### PR DESCRIPTION
This changes the way /datum/modifier/aura works to check for line of sight within range instead of just checking for range.

This datum is used in only two places, for hivebot commander buffs and for pink slime heals.

The reason for the change is to patch the exploit that allowed one to put docile pink slimes into a vore belly and get free healing.

Nothing else about the healing is touched, the intent is to preserve current healing abilities but to require active protection of the slime.