### PR TITLE
Promethean Internal Bleed Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -346,6 +346,13 @@
 
 		handle_organs() // Update everything
 
+		for(var/obj/item/organ/external/O in src.bad_external_organs)
+			for(var/datum/wound/W in O.wounds)
+				if(W.internal)
+					W.damage = 0
+					O.wounds -= W
+					to_chat(src, "<span class='notice'>You feel a tightening sensation as [O.name] clots.</span>")
+
 		update_icons_body()
 		active_regen = FALSE
 	else

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -351,7 +351,7 @@
 				if(W.internal)
 					W.damage = 0
 					O.wounds -= W
-					to_chat(src, "<span class='notice'>You feel a tightening sensation as [O.name] clots.</span>")
+					to_chat(src, "<span class='notice'>You feel a tightening sensation as your [O.name] clots internal damage.</span>")
 
 		update_icons_body()
 		active_regen = FALSE


### PR DESCRIPTION
Prometheans getting internal bleeds doesn't make a lot of sense, so this PR seeks to resolve this issue.

Rather than make prommies immune, I added the ability for their limb regeneration ability to repair internal bleeds so they still need to worry about the injury, but it shouldn't snowball into instant death as easily.

Prometheans will not fix external bleeds this way, and will still need standard medical intervention for regular wounds and blood levels are unaffected by regeneration so transfusions will also be required.