### PR TITLE
Osteodaxon Rebalance

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -711,11 +711,11 @@
 	overdose_mod = 1.5
 	scannable = 1
 
-/datum/reagent/osteodaxon/proc/FixBones(var/mob/living/carbon/human/H)
+/datum/reagent/osteodaxon/proc/FixBones(var/mob/living/carbon/human/H) // Pushed off to it's own proc since we'll need to use it both for ingest and blood.
 	for(var/obj/item/organ/external/O in H.bad_external_organs)
 		if(O.status & ORGAN_BROKEN)
 			O.mend_fracture()		//Only works if the bone won't rebreak, as usual
-			H.custom_pain("You feel a terrible agony tear through your bones!",150)
+			H.custom_pain("You feel a terrible agony tear through your bones!",80)
 			H.adjustHalLoss(15) // Fixing bones hurts like fuck
 			H.AdjustWeakened(1)		//Bones being regrown will knock you over
 
@@ -730,16 +730,16 @@
 		if(rand(1,3) == 3)	// We don't want to spam pain messages
 			switch(rand(1,5))
 				if(1)
-					H.custom_pain("It feels like your bones are on fire!", 120)
+					H.custom_pain("It feels like your bones are on fire!", 120) // While more efficient, we get a LOT more pain.
 				if(2)
-					H.custom_pain("You feel your bones shifting under your skin!", 120)
+					H.custom_pain("You feel your bones shifting under your skin!", 120) // This pain is enough that Oxycodone or anesthetic will be required.
 				if(3)
 					H.custom_pain("Your bones ripple and contort agonizingly!", 120)
 				if(4)
 					H.custom_pain("Every bone in your body is screaming for help!", 120)
 				if(5)
 					H.custom_pain("Your bones feel as if they're fighting against your every movement!", 120)
-		if(dose >= 4) // We need four units for repairs to happen.
+		if(dose >= 4) // In blood osteo is more efficient
 			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
 			FixBones(H)
 
@@ -757,7 +757,7 @@
 				if(2)
 					H.custom_pain("Your bones are hardening painfully beneath your skin.", 80)
 				if(3)
-					H.custom_pain("You feel an uncomftorble shifting in your bones.", 80)
+					H.custom_pain("You feel an uncomfortable shifting in your bones.", 80)
 				if(4)
 					H.custom_pain("Your bones ache!", 80)
 				if(5)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -717,7 +717,7 @@
 			O.mend_fracture()		//Only works if the bone won't rebreak, as usual
 			H.adjustHalLoss(15) // Fixing bones hurts like fuck
 			H.adjustBruteLoss(0.5) // Your bones are rapidly mending, that may cause some tissue damage.
-			H.custom_pain("You feel a terrible agony tear through your bones!",60)
+			H.custom_pain("You feel a terrible agony tear through your bones!",150)
 			H.AdjustWeakened(1)		//Bones being regrown will knock you over
 
 /datum/reagent/osteodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -731,16 +731,16 @@
 		if(rand(1,3) == 3)	// We don't want to spam pain messages
 			switch(rand(1,5))
 				if(1)
-					H.custom_pain("It feels like your bones are on fire!", 90)
+					H.custom_pain("It feels like your bones are on fire!", 120)
 				if(2)
-					H.custom_pain("You feel your bones shifting under your skin!", 90)
+					H.custom_pain("You feel your bones shifting under your skin!", 120)
 				if(3)
-					H.custom_pain("Your bones ripple and contort agonizingly!", 90)
+					H.custom_pain("Your bones ripple and contort agonizingly!", 120)
 				if(4)
-					H.custom_pain("Every bone in your body is screaming for help!", 90)
+					H.custom_pain("Every bone in your body is screaming for help!", 120)
 				if(5)
-					H.custom_pain("Your bones feel as if they're fighting against your every movement!", 90)
-		if(dose >= 4) // We need four units for repairs to happen.
+					H.custom_pain("Your bones feel as if they're fighting against your every movement!", 120)
+		if(dose >= 5) // We need four units for repairs to happen.
 			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
 			FixBones(H)
 
@@ -763,7 +763,7 @@
 					H.custom_pain("Your bones ache!", 80)
 				if(5)
 					H.custom_pain("A light pain shoots through your bones.", 80)
-		if(dose >= 8)
+		if(dose >= 10)
 			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
 			FixBones(H)
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -715,9 +715,8 @@
 	for(var/obj/item/organ/external/O in H.bad_external_organs)
 		if(O.status & ORGAN_BROKEN)
 			O.mend_fracture()		//Only works if the bone won't rebreak, as usual
-			H.adjustHalLoss(15) // Fixing bones hurts like fuck
-			H.adjustBruteLoss(0.5) // Your bones are rapidly mending, that may cause some tissue damage.
 			H.custom_pain("You feel a terrible agony tear through your bones!",150)
+			H.adjustHalLoss(15) // Fixing bones hurts like fuck
 			H.AdjustWeakened(1)		//Bones being regrown will knock you over
 
 /datum/reagent/osteodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -740,7 +739,7 @@
 					H.custom_pain("Every bone in your body is screaming for help!", 120)
 				if(5)
 					H.custom_pain("Your bones feel as if they're fighting against your every movement!", 120)
-		if(dose >= 5) // We need four units for repairs to happen.
+		if(dose >= 4) // We need four units for repairs to happen.
 			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
 			FixBones(H)
 
@@ -763,7 +762,7 @@
 					H.custom_pain("Your bones ache!", 80)
 				if(5)
 					H.custom_pain("A light pain shoots through your bones.", 80)
-		if(dose >= 10)
+		if(dose >= 8)
 			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
 			FixBones(H)
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -711,17 +711,61 @@
 	overdose_mod = 1.5
 	scannable = 1
 
+/datum/reagent/osteodaxon/proc/FixBones(var/mob/living/carbon/human/H)
+	for(var/obj/item/organ/external/O in H.bad_external_organs)
+		if(O.status & ORGAN_BROKEN)
+			O.mend_fracture()		//Only works if the bone won't rebreak, as usual
+			H.adjustHalLoss(15) // Fixing bones hurts like fuck
+			H.adjustBruteLoss(0.5) // Your bones are rapidly mending, that may cause some tissue damage.
+			H.custom_pain("You feel a terrible agony tear through your bones!",60)
+			H.AdjustWeakened(1)		//Bones being regrown will knock you over
+
 /datum/reagent/osteodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/external/O in H.bad_external_organs)
-			if(O.status & ORGAN_BROKEN)
-				O.mend_fracture()		//Only works if the bone won't rebreak, as usual
-				H.custom_pain("You feel a terrible agony tear through your bones!",60)
-				H.AdjustWeakened(1)		//Bones being regrown will knock you over
+
+		M.adjustHalLoss(4) // Every tick we matabolize Osteo it HURTS.
+		if(rand(1,3) == 3)	// We don't want to spam pain messages
+			switch(rand(1,5))
+				if(1)
+					H.custom_pain("It feels like your bones are on fire!", 90)
+				if(2)
+					H.custom_pain("You feel your bones shifting under your skin!", 90)
+				if(3)
+					H.custom_pain("Your bones ripple and contort agonizingly!", 90)
+				if(4)
+					H.custom_pain("Every bone in your body is screaming for help!", 90)
+				if(5)
+					H.custom_pain("Your bones feel as if they're fighting against your every movement!", 90)
+		if(dose >= 4) // We need four units for repairs to happen.
+			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
+			FixBones(H)
+
+/datum/reagent/osteodaxon/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+
+		M.adjustHalLoss(2) // Every tick we matabolize Osteo it HURTS.
+		if(rand(1,3) == 3)	// We don't want to spam pain messages
+			switch(rand(1,5))
+				if(1)
+					H.custom_pain("You feel a light rippling in your bones!", 80)
+				if(2)
+					H.custom_pain("Your bones are hardening painfully beneath your skin.", 80)
+				if(3)
+					H.custom_pain("You feel an uncomftorble shifting in your bones.", 80)
+				if(4)
+					H.custom_pain("Your bones ache!", 80)
+				if(5)
+					H.custom_pain("A light pain shoots through your bones.", 80)
+		if(dose >= 8)
+			M.heal_organ_damage(3 * removed, 0)	//Gives the bones a chance to set properly even without other meds
+			FixBones(H)
 
 /datum/reagent/myelamine
 	name = "Myelamine"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4298,6 +4298,7 @@
 #include "maps\expedition_vr\beach\submaps\mountains.dm"
 #include "maps\expedition_vr\beach\submaps\mountains_areas.dm"
 #include "maps\gateway_archive_vr\blackmarketpackers.dm"
+#include "maps\groundbase\groundbase.dm"
 #include "maps\redgate\fantasy_items.dm"
 #include "maps\redgate\code\snowglobe_rs.dm"
 #include "maps\southern_cross\items\clothing\sc_accessory.dm"
@@ -4316,7 +4317,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\funny_name.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4298,7 +4298,6 @@
 #include "maps\expedition_vr\beach\submaps\mountains.dm"
 #include "maps\expedition_vr\beach\submaps\mountains_areas.dm"
 #include "maps\gateway_archive_vr\blackmarketpackers.dm"
-#include "maps\groundbase\groundbase.dm"
 #include "maps\redgate\fantasy_items.dm"
 #include "maps\redgate\code\snowglobe_rs.dm"
 #include "maps\southern_cross\items\clothing\sc_accessory.dm"
@@ -4317,6 +4316,7 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\funny_name.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
### **Lore Dump:** 

Due to over use of Osteodaxon by NT Personnel a sharp decrease in drug effectiveness has been detected! We suspect this is caused by growing crew tolerance to the drug, and to combat this we recommend increased dosages! Do be aware, there may be some unwanted side effects, so it is recommended crew are anesthetized while undergoing treatment.

### Standard PR Info:

**The Problem:** 

Osteodaxon is an easy chem to obtain, and it is incredibly efficient, with .1 units being enough to treat every broken bone in someone's body.

Recently, medical has found several speed running strats to ensure it can be obtained without even the minimal effort of engaging with space carp.

This is causing issues where surgeons are being pushed to the wayside from the one injury they can reliably encounter as the pill fixes it faster and with no drawbacks.

**The Solution:**

Osteodaxon has been nerfed across the board in this PR, specifically it was adjusted to cause HalLoss while processing, and a dosage of 4 units is needed to fix broken bones if injected. Pain given will be greater than even ParaTram can counter, requiring the patient be put under while metabolizing the chem or to be administered oxycodone. Even then, the halloss is likely to put them into crit for a short time.

When applied as a pill Osteo will require 8 units to process before bones are fixed, but as a trade off it causes less halloss and the pain levels are manageable with ParaTram.

Further, 15 units of halloss are applied at the final repair and pain levels for the bone repair message were buffed.

### TL;DR

- Osteo no longer fixes bones at any dosage.
- As an injection 4 Units are required, this allows for easy dosage from a bottle to a syringe.
- Pain and Halloss are applied, enough to put the patient into paincrit without medical attention.
- As a pill, 8 Units are required, however less pain is given per tick and the pain is low enough to be treated with ParaTram.
- When fixed, 15 Halloss will be applied.
- 4 Units of HalLoss are applied as it metabolizes in the bloodstream, building up paincrit quickly
- 2 Units of HalLoss are applied as it metabolizes in the stomach, making it the lower pain option with a longer time to finish and higher chem cost.