### PR TITLE
Fix river leech

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
@@ -242,6 +242,9 @@
 	do_infest(usr)
 
 /mob/living/simple_mob/animal/sif/leech/proc/do_infest(var/mob/living/user, var/mob/living/target = null)
+	if(docile) //RS Add
+		return
+
 	if(host)
 		to_chat(user, span("alien", "We are already within a host."))
 		return
@@ -341,6 +344,11 @@
 
 	host = null
 
+	// RS Add
+	if(docile)
+		VARSET_IN(src, docile, FALSE, 60 SECONDS)
+	// RS Add End
+
 /mob/living/simple_mob/animal/sif/leech/verb/inject_victim()
 	set category = "Abilities"
 	set name = "Incapacitate Potential Host"
@@ -369,7 +377,7 @@
 	poison_inject(usr, M)
 
 /mob/living/simple_mob/animal/sif/leech/proc/poison_inject(var/mob/living/user, var/mob/living/carbon/L)
-	if(!L || !Adjacent(L) || stat)
+	if(!L || !Adjacent(L) || stat || docile) //RS Edit
 		return
 
 	var/mob/living/carbon/human/H = L
@@ -407,7 +415,7 @@
 		inject_meds(chem)
 
 /mob/living/simple_mob/animal/sif/leech/proc/inject_meds(var/chem)
-	if(host)
+	if(host && !docile) // RS Edit
 		chemicals = max(1, chemicals - 50)
 		host.reagents.add_reagent(chem, 5)
 		to_chat(src, span("alien","We injected \the [host] with five units of [chem]."))
@@ -445,6 +453,9 @@
 		to_chat(src, span("warning","We cannot feed now."))
 
 /mob/living/simple_mob/animal/sif/leech/proc/bite_organ(var/obj/item/organ/internal/O)
+	if(docile) //RS Add
+		return
+
 	last_feeding = world.time
 
 	if(O)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -247,6 +247,11 @@
 				target.release_control()
 			worm.detatch()
 			worm.leave_host()
+		// RS Add - Handle river leeches (this should probably get generalized)
+		else if(istype(obj,/mob/living/simple_mob/animal/sif/leech))
+			var/mob/living/simple_mob/animal/sif/leech/leech = obj
+			leech.leave_host()
+		// RS Add End
 		else
 			obj.loc = get_turf(target)
 			obj.add_blood(target)


### PR DESCRIPTION
The implant removal surgery makes special account of borers, but not river leeches. This fixes the 'still connected to host over infinite distance'.

Additionally tweaks things about leeches: I think they were intended to be player-controlled because there are some things that apply to player-controlled ones (cordradaxon making them docile only applies to players and not AI based on how the code was written).

Now, if you inject a host with cordradaxon, wait one life tick (so a few seconds) and then remove it, it will be removed while docile, which prevents any special ability use by player or AI control. So, should have a much easier time murdering it. They will remain docile for 60 seconds if removed while docile.
(Untested)