### PR TITLE
Fixes Morph Overlays

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -173,8 +173,7 @@
 
 	density = initial(density)
 
-	cut_overlays(TRUE) //ALL of zem
-
+	cut_overlays() // Remove all overlays.
 	maptext = null
 
 	size_multiplier = our_size_multiplier


### PR DESCRIPTION
Fixes overlays sticking on morphs after dropping a disguise.

Issue was caused by passing TRUE into the proc, cut_overlays which causes it to only remove priority overlays and leave the rest.

An example of the issue in question:
![cursedmorph](https://github.com/TS-Rogue-Star/Rogue-Star/assets/78667902/f8426014-c67e-4739-871f-b45baf82146d)

And an example of the patched version:
![fixedmorph](https://github.com/TS-Rogue-Star/Rogue-Star/assets/78667902/e5c7ab94-c00d-4e4b-a3c4-407c4626d788)
