### PR TITLE
Avoid teleporting DIRECTLY onto another portal

### DIFF
--- a/code/modules/multiz/portals_vr.dm
+++ b/code/modules/multiz/portals_vr.dm
@@ -164,6 +164,10 @@
 /obj/structure/portal_event/proc/find_our_turf(var/atom/movable/AM)
 	var/offset_x = x - AM.x
 	var/offset_y = y - AM.y
+	// RS Add - Avoid infinite teleport loops
+	if(!offset_x && !offset_y)
+		offset_y = 1 // Just go this way.
+	// RS Add End
 
 	var/turf/temptarg = locate((target.x + offset_x),(target.y + offset_y),target.z)
 


### PR DESCRIPTION
You could alternatively attempt to locate() a portal on the destination and not teleport in that case, but I think it's nicer to just have it at least try to move them near the destination so that an admin can bamf someone onto a portal directly and have it work reasonably well if there's a spot +1 y available on the other side.
(Untested)