### PR TITLE
Adding Xenobiology Bags to Lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -44,7 +44,8 @@
 
 	starts_with = list(
 		/obj/item/clothing/suit/bio_suit/scientist,
-		/obj/item/clothing/head/bio_hood/scientist)
+		/obj/item/clothing/head/bio_hood/scientist,
+		/obj/item/weapon/storage/bag/xeno = 2)
 
 /obj/structure/closet/l3closet/scientist/double
 	starts_with = list(


### PR DESCRIPTION
These bags were added to Virgo a while back, but never spawn because I added them to the wrong locker type.

This fixes that issue, all types of xenobio lockers will spawn with Xenobiology Bags now.