### PR TITLE
Protean Species and Abilities Overhaul [Feedback/Testing]

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -267,17 +267,17 @@
 	if(!istype(humanform.species,/datum/species/protean)) // ???
 		return
 	var/datum/species/protean/S = humanform.species
-	if(S.prot_healing_allowed)
-		if(. && istype(refactory) && humanform)
-			if(!healing && (human_brute || human_burn) && refactory.get_stored_material(MAT_STEEL) >= 100)
-				healing = humanform.add_modifier(/datum/modifier/protean/steel, origin = refactory)
-			else if(healing && !(human_brute || human_burn))
-				healing.expire()
-				healing = null
-				S.prot_healing_allowed = FALSE
-	else if(!S.prot_healing_allowed && healing)
+	if(!S.prot_healing_allowed && healing)
 		healing.expire()
 		healing = null
+		return
+	if(. && istype(refactory) && humanform)
+		if(!healing && (human_brute || human_burn) && refactory.get_stored_material(MAT_STEEL) >= 100)
+			healing = humanform.add_modifier(/datum/modifier/protean/steel, origin = refactory)
+		else if(healing && !(human_brute || human_burn))
+			healing.expire()
+			healing = null
+			S.prot_healing_allowed = FALSE
 	//RS Edit End
 /mob/living/simple_mob/protean_blob/lay_down()
 	..()

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -19,12 +19,12 @@
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm = "hits"
-
-	harm_intent_damage = 2
-	melee_damage_lower = 5
-	melee_damage_upper = 5
-	attacktext = list("slashed")
-
+	//RS Edit (removed blob damage, Crates, Airlocks, Lockers, Tanking Mobs)
+	harm_intent_damage = 0
+	melee_damage_lower = 0
+	melee_damage_upper = 0
+	//attacktext = list("slashed")
+	//RS Edit End
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0
@@ -44,10 +44,12 @@
 	var/obj/prev_left_hand
 	var/obj/prev_right_hand
 
+	var/stored_brute = 0
+	var/stored_burn = 0
 	var/human_brute = 0
 	var/human_burn = 0
-
-	player_msg = "In this form, you can move a little faster, your health will regenerate as long as you have metal in you, and you can ventcrawl!"
+	//RS Edit (blob message adjust)
+	player_msg = "In this form, you can move a little faster, healing does not require power, and you can ventcrawl!"
 
 	can_buckle = TRUE //Blobsurfing
 
@@ -247,13 +249,22 @@
 
 /mob/living/simple_mob/protean_blob/Life()
 	. = ..()
-	if(. && istype(refactory) && humanform)
-		if(!healing && (human_brute || human_burn) && refactory.get_stored_material(MAT_STEEL) >= 100)
-			healing = humanform.add_modifier(/datum/modifier/protean/steel, origin = refactory)
-		else if(healing && !(human_brute || human_burn))
-			healing.expire()
-			healing = null
-
+	//RS Edit Toggling of blob healing with ability
+	if(!istype(humanform.species,/datum/species/protean)) // ???
+		return
+	var/datum/species/protean/S = humanform.species
+	if(S.prot_healing_allowed)
+		if(. && istype(refactory) && humanform)
+			if(!healing && (human_brute || human_burn) && refactory.get_stored_material(MAT_STEEL) >= 100)
+				healing = humanform.add_modifier(/datum/modifier/protean/steel, origin = refactory)
+			else if(healing && !(human_brute || human_burn))
+				healing.expire()
+				healing = null
+				S.prot_healing_allowed = FALSE
+	else if(!S.prot_healing_allowed && healing)
+		healing.expire()
+		healing = null
+	//RS Edit End
 /mob/living/simple_mob/protean_blob/lay_down()
 	..()
 	if(resting)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -36,7 +36,17 @@
 	minbodytemp = 0
 	maxbodytemp = 900
 	movement_cooldown = -0.5 // Should mean that the little blurb about being quicker in blobform rings true. May need further adjusting.
-
+	//RS Add (Squish emotes!)
+	var/list/default_emotes = list(
+		/decl/emote/audible/squish,
+		/decl/emote/visible/bounce,
+		/decl/emote/visible/jiggle,
+		/decl/emote/visible/vibrate,
+		/decl/emote/visible/flip,
+		/decl/emote/visible/spin,
+		/decl/emote/visible/floorspin
+	)
+	//RS Add End
 	var/mob/living/carbon/human/humanform
 	var/obj/item/organ/internal/nano/refactory/refactory
 	var/datum/modifier/healing
@@ -93,7 +103,11 @@
 	return "synthetic"
 
 /mob/living/simple_mob/protean_blob/get_available_emotes()
-	return global._robot_default_emotes.Copy()
+	var/list/fulllist = global._robot_default_emotes.Copy() //RS Edit (var/list/fulllist Formerly return)
+	//RS Add (Squish emotes!)
+	fulllist += default_emotes
+	return fulllist
+	//RS Add End
 
 /mob/living/simple_mob/protean_blob/init_vore()
 	return //Don't make a random belly, don't waste your time

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -321,6 +321,7 @@
 		return
 	else
 		//RS Edit (no blobbing while arrested/unconcious)
+		to_chat(src,"<span class='notice'>Your form starts to shift as you begin to collapse into a gooey blob.</span>")
 		visible_message("<b>[src.name]</b> starts to collapse into a gooey blob!")
 		if(do_after(src,10 SECONDS))
 			if(stat || paralysis || stunned || restrained()) //Double check to make sure we didnt get KO'd during our do_after()

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -343,7 +343,7 @@
 					to_chat(src,"<span class='warning'>Blobbing interrupted.</span>")
 					active_regen = FALSE //Global Protean Ability active chec
 					return
-					nano_intoblob()
+				nano_intoblob()
 			active_regen = FALSE
 			//RS Edit End
 

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -195,7 +195,7 @@
 					var/limb_path = organ_data["path"]
 					var/obj/item/organ/O = new limb_path(src)
 					organ_data["descriptor"] = O.name
-					to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
+					to_chat(src, "<span class='notice'>You feel a shifting sensation as your [O.name] reconsitutes.</span>")
 
 
 

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -45,13 +45,12 @@
 	oxy_mod =		0
 	item_slowdown_mod = 1.33
 	//RS Edit (why defining temp twice?)
-	cold_level_1 = -INFINITY //Default 260 - Lower is better
-	cold_level_2 = -INFINITY//Default 200
-	cold_level_3 = -INFINITY //Default 120
-
-	heat_level_1 = INFINITY //Default 360
-	heat_level_2 = INFINITY //Default 400
-	heat_level_3 = INFINITY //Default 1000
+	cold_level_1 = -INFINITY
+	cold_level_2 = -INFINITY
+	cold_level_3 = -INFINITY
+	heat_level_1 = 420 //Proper temperatures
+	heat_level_2 = 480
+	heat_level_3 = 1100
 	//RS edit end
 	hazard_low_pressure = -1 //Space doesn't bother them
 	hazard_high_pressure = 200 //They can cope with slightly higher pressure
@@ -92,7 +91,7 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/unbreakable/nano)
 		)
 
-	heat_discomfort_strings = list("You feel too warm.")
+	heat_discomfort_strings = list("WARNING: Temperature exceeding acceptable thresholds!.")//Hot message more robotic
 	cold_discomfort_strings = list("You feel too cool.")
 
 	//These verbs are hidden, for hotkey use only

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -154,7 +154,7 @@
 
 	// Heal remaining damage.
 	if(prot_healing_allowed)
-		//to_chat(H,"<span class='notice'> Healing Proc")
+		//to_chat(H,"<span class='notice'> Healing Proc</span>")
 		if(H.getActualBruteLoss() || H.getActualFireLoss())
 			var/nutrition_cost = 0		// The total amount of nutrition drained every tick, when healing
 			var/nutrition_debt = 0		// Holder variable used to store previous damage values prior to healing for use in the nutrition_cost equation.
@@ -183,7 +183,7 @@
 
 						nutrition_cost += to_pay
 					else
-						to_chat(H,"<span class='notice'> Damage Taken, Deactivating Regeneration.")
+						to_chat(H,"<span class='notice'> Damage Taken, Deactivating Regeneration.</span>")
 						prot_healing_allowed = FALSE
 						stored_brute = 0
 						stored_burn = 0
@@ -196,7 +196,7 @@
 						stored_burn = current_burn
 						nutrition_cost += to_pay
 					else
-						to_chat(H,"<span class='notice'> Damage Taken, Deactivating Regeneration.")
+						to_chat(H,"<span class='notice'> Damage Taken, Deactivating Regeneration.</span>")
 						prot_healing_allowed = FALSE
 						stored_brute = 0
 						stored_burn = 0
@@ -205,12 +205,12 @@
 						return
 					H.adjust_nutrition(-(3 * nutrition_cost)) // Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
 				else
-					to_chat(H,"<span class='notice'> Not enough power remaining, Deactivating Regeneration.")
+					to_chat(H,"<span class='notice'> Not enough power remaining, Deactivating Regeneration.</span>")
 					prot_healing_allowed = FALSE
 					stored_brute = 0
 					stored_burn = 0
 		else
-			to_chat(H,"<span class='notice'> Healing Completed, Deactivating Regeneration.")
+			to_chat(H,"<span class='notice'> Healing Completed, Deactivating Regeneration.</span>")
 			prot_healing_allowed = FALSE
 			stored_brute = 0
 			stored_burn = 0

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -9,7 +9,6 @@
 /obj/item/organ/external/groin/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	cannot_gib = 0
 	max_damage = 30 // <-- This is different from the rest
 	min_broken_damage = 1000 //Multiple
 	vital = TRUE //RS Edit (counts towards dying now)

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -9,13 +9,15 @@
 /obj/item/organ/external/groin/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
+	cannot_gib = 0
 	max_damage = 30 // <-- This is different from the rest
 	min_broken_damage = 1000 //Multiple
-	vital = FALSE
+	vital = TRUE //RS Edit (counts towards dying now)
 	model = "protean"
 /obj/item/organ/external/head/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
+	cannot_gib = 0 //RS Edit (Can be destroyed, if not desired set vital to 1 to count towards death)
 	max_damage = 30
 	min_broken_damage = 1000 //Inheritance
 	vital = FALSE


### PR DESCRIPTION
Hello dear readers, I have played as a protean for a long time (Back since they first hit public whitelist on virgo), and while they are a fun and interesting species, they are not without their problems. This PR seeks to resolve most of those problems, and rebalance some of their abilities that some may consider "powergaming". Below I have listed their issues, and how I have attempted to resolve them.

Problems with old prots / Feels bad to play as:
Having to blob for even the tiniest bit of damage.
Having to blob for replacing a limb of any kind.
Blobbing dropping everything you're wearing for the above, breaking rigsuits and some other things.


Gameplay that felt odd/Overpowered:
Proteans in blob form (simple mob) can smash open airlocks (even bolted), secure crates/lockers, and generally kill off most simple mobs so long as they have steel.
Full Refactor -> rebuild Basically grants an Aheal, trading 5 steel for removing ALL your damage after damage, even giving you a new NiF.
Blob form being able to be used as a quick escape from just about any situation.
Proteans could not be arrested, as they could just blob out of straitjackets/cuffs (prommies cant do it, why can prots)


New ability added:
Toggle Regeneration: (100 steel per operation, Regen Rate unchanged)
Going into blob form no longer instantly starts healing you, it must be toggled on/off with this ability.
Ability works while not blobbed too, but additionally costs power (nutrition) to run.
Ability will be turned off automatically if injured (excluding in blob form, cant quite figure that one out)
Ability will turn off automatically if you 1. Run out of steel. 2. Run out of power (blob form excluded) 3. Take damage (noted above)
Ability takes ~5 seconds to actually turn on, which you must remain still for (cant just tap regeneration on while youre in combat)
Ability -does- work if youre in crit, but simple mobs will guaranteed beat your ass if you try this.

Abilities Changed:
Blob form:
Has a 5 second Do after (that reports to nearby users that its occuring)
cannot be done if: Stunned (purple stun icon) Paralyzed (red stun icon) Or handcuffed (arrestable proots)

Mass adjust (size change):
Removed the steel requirement/refund when changing sizes.
Its more of a scene tool kind of thing, and none of the other size change mechanics require this silly resource.
It was also usable to just become smaller and gain more steel for regenning leading to some balance concerns.

Reform - Single Limb: 2000 steel (1 sheet)
Removed blobbing requirement, added a 10 second stay still period.
Fixed it taking your steel until -after- the operation is completed.

Reform - Whole body: 10000 Steel (5 sheets, all your capacity)
Swapped the old method out for a small recode of the "regenerate" verb
Has a 30 second stand still period.
No longer requires blobbing.
Will regenerate your Missing limbs and Fix/Regenerate internal organs (there's no way to do this otherwise)
Does NOT heal body damage, Leaving you with all your wounds you had previously (does fix stumps though and their associated damage)


Gameplay / Balancing changes (general):
Removed Blob form (simple mob's) damage:
No more smashing open Crates/Lockers Or opening airlock doors without access bolted or not (Looking at you alien ship)
Makes blob your "I need to get out of here, fast." Form, or shifts it towards scene play

You can now blow a proteans head off after 50 damage of any kind, no longer can they just tank hits here.
Groin/Pelvis also tagged as "vital" and damage here counts towards their death

The two above changes fix them recieving >200 damage then blobbing resulting in you just instantly gibbing

