### PR TITLE
Removes carpotoxin from Classic Terran Caviar

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -6994,7 +6994,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/canned/caviar/true
 	name = "\improper Classic Terran Caviar"
 	icon_state = "carpeggs"
-	desc = "Terran caviar, or space carp eggs. Banned by the Vir Food Health Administration for exceeding the legally set amount of carpotoxins in food stuffs."
+	desc = "Terran caviar, or space carp eggs. Banned by the Vir Food Health Administration for exceeding the legally set amount of seafood based toxins in food stuffs."
 	trash = /obj/item/trash/carpegg
 	canned_open_state = "carpeggs-open"
 	filling_color = "#330066"
@@ -7005,7 +7005,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/canned/caviar/true/Initialize()
 	. = ..()
 	reagents.add_reagent("seafood", 4)
-	reagents.add_reagent("carpotoxin", 1)
+	reagents.add_reagent("toxin", 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/canned/maps
 	name = "\improper MAPS"


### PR DESCRIPTION
Posted with permission from VerySoft.

Osteodaxon is too powerful for something that can be obtained as easily as hacking a vendor and by existing so easily takes away jobs from surgeon players.  Making it so carp is the main source of carpotoxin encourages some interaction between departments in order to achieve this kind of power, either by asking a miner to help get a carp on Stellar Delight, or a pilot for help on Rascal's Pass.