### PR TITLE
Makes shadekin bellies escapable

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -152,7 +152,7 @@
 	B.name = vore_stomach_name ? vore_stomach_name : "stomach"
 	B.desc = vore_stomach_flavor ? vore_stomach_flavor : "Your surroundings are warm, soft, and slimy. Makes sense, considering you're inside \the [name]."
 	B.digest_mode = vore_default_mode
-	B.escapable = vore_escape_chance > 0
+	B.escapable = 1
 	B.escapechance = vore_escape_chance
 	B.digestchance = vore_digest_chance
 	B.absorbchance = vore_absorb_chance


### PR DESCRIPTION
Does as the title says, makes shadekin simple mobs (and their subtypes) always have escapable set to 1, (not their actual escapechance, which is 25% still)