### PR TITLE
Port chomp crawling (reup)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -68,7 +68,7 @@
 		CtrlClickOn(A)
 		return 1
 
-	if(stat || paralysis || stunned || weakened)
+	if(stat || paralysis || stunned) //CHOMPedit, removed weakened to allow item use while crawling
 		return
 
 	face_atom(A) // change direction to face what you clicked on

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -68,7 +68,7 @@
 		CtrlClickOn(A)
 		return 1
 
-	if(stat || paralysis || stunned) //CHOMPedit, removed weakened to allow item use while crawling
+	if(stat || paralysis || stunned) //RS Port Chomp PR 8154 ||  CHOMPedit, removed weakened to allow item use while crawling
 		return
 
 	face_atom(A) // change direction to face what you clicked on

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -736,7 +736,7 @@
 		return TURRET_NOT_TARGET
 
 	if(check_synth || check_all)	//If it's set to attack all non-silicons or everything, target them!
-		if(L.lying)
+		if(L.lying && (L.incapacitated(INCAPACITATION_KNOCKOUT) || L.incapacitated(INCAPACITATION_STUNNED))) // CHOMPEdit - Crawling targets are dangerous, if they are able.
 			return check_down ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
 		return TURRET_PRIORITY_TARGET
 
@@ -753,7 +753,7 @@
 		if(assess_perp(L) < 4)
 			return TURRET_NOT_TARGET	//if threat level < 4, keep going
 
-	if(L.lying)		//if the perp is lying down, it's still a target but a less-important target
+	if(L.lying && (L.incapacitated(INCAPACITATION_KNOCKOUT) || L.incapacitated(INCAPACITATION_STUNNED)))		//if the perp is lying down, it's still a target but a less-important target - CHOMPEdit - Crawling targets are dangerous, if they are able.
 		return check_down ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
 
 	return TURRET_PRIORITY_TARGET	//if the perp has passed all previous tests, congrats, it is now a "shoot-me!" nominee

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -736,7 +736,7 @@
 		return TURRET_NOT_TARGET
 
 	if(check_synth || check_all)	//If it's set to attack all non-silicons or everything, target them!
-		if(L.lying && (L.incapacitated(INCAPACITATION_KNOCKOUT) || L.incapacitated(INCAPACITATION_STUNNED))) // CHOMPEdit - Crawling targets are dangerous, if they are able.
+		if(L.lying && (L.incapacitated(INCAPACITATION_KNOCKOUT) || L.incapacitated(INCAPACITATION_STUNNED))) //RS Port Chomp PR 7822 || CHOMPEdit - Crawling targets are dangerous, if they are able.
 			return check_down ? TURRET_SECONDARY_TARGET : TURRET_NOT_TARGET
 		return TURRET_PRIORITY_TARGET
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -114,13 +114,13 @@ var/list/slot_equipment_priority = list( \
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(var/obj/item/W)
-	if(lying || !istype(W))
+	if(/*lying || */!istype(W)) // CHOMPEdit - Don't care about lying, give me.
 		return 0
 	return 1
 
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_r_hand(var/obj/item/W)
-	if(lying || !istype(W))
+	if(/*lying || */!istype(W)) // CHOMPEdit - Don't care about lying, give me.
 		return 0
 	return 1
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -114,13 +114,13 @@ var/list/slot_equipment_priority = list( \
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(var/obj/item/W)
-	if(/*lying || */!istype(W)) // CHOMPEdit - Don't care about lying, give me.
+	if(/*lying || */!istype(W)) //RS Port Chomp PR 7822 || CHOMPEdit - Don't care about lying, give me.
 		return 0
 	return 1
 
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_r_hand(var/obj/item/W)
-	if(/*lying || */!istype(W)) // CHOMPEdit - Don't care about lying, give me.
+	if(/*lying || */!istype(W)) //RS Port Chomp PR 7822 || CHOMPEdit - Don't care about lying, give me.
 		return 0
 	return 1
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1448,9 +1448,14 @@
 		if(C.body_parts_covered & FEET)
 			footcoverage_check = TRUE
 			break
+	if(lying) // CHOMPadd - Drops stuff from hands, but no sleep.
+		playsound(src, 'sound/misc/slip.ogg', 25, 1, -1)
+		drop_both_hands()
+		return 0
 	if((species.flags & NO_SLIP && !footcoverage_check) || (shoes && (shoes.item_flags & NOSLIP))) //Footwear negates a species' natural traction.
 		return 0
 	if(..(slipped_on,stun_duration))
+		drop_both_hands() // CHOMPAdd - Drops stuff from both hands
 		return 1
 
 /mob/living/carbon/human/proc/relocate()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1448,14 +1448,14 @@
 		if(C.body_parts_covered & FEET)
 			footcoverage_check = TRUE
 			break
-	if(lying) // CHOMPadd - Drops stuff from hands, but no sleep.
+	if(lying) //RS Port Chomp PR 7822 || CHOMPadd - Drops stuff from hands, but no sleep.
 		playsound(src, 'sound/misc/slip.ogg', 25, 1, -1)
 		drop_both_hands()
 		return 0
 	if((species.flags & NO_SLIP && !footcoverage_check) || (shoes && (shoes.item_flags & NOSLIP))) //Footwear negates a species' natural traction.
 		return 0
 	if(..(slipped_on,stun_duration))
-		drop_both_hands() // CHOMPAdd - Drops stuff from both hands
+		drop_both_hands() //RS Port Chomp PR 7822 || CHOMPAdd - Drops stuff from both hands
 		return 1
 
 /mob/living/carbon/human/proc/relocate()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -313,6 +313,7 @@
 				apply_effect(3, WEAKEN, armor_check)
 				playsound(src, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 				if(armor_check < 60)
+					drop_both_hands()	// CHOMPEdit - We've been pushed! Drop our stuff as well
 					visible_message("<span class='danger'>[M] has pushed [src]!</span>")
 				else
 					visible_message("<span class='warning'>[M] attempted to push [src]!</span>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -313,7 +313,7 @@
 				apply_effect(3, WEAKEN, armor_check)
 				playsound(src, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 				if(armor_check < 60)
-					drop_both_hands()	// CHOMPEdit - We've been pushed! Drop our stuff as well
+					drop_both_hands()	//RS Port Chomp PR 7822 || CHOMPEdit - We've been pushed! Drop our stuff as well
 					visible_message("<span class='danger'>[M] has pushed [src]!</span>")
 				else
 					visible_message("<span class='warning'>[M] attempted to push [src]!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -808,6 +808,15 @@
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return 0
 
+// CHOMPAdd - Drop both things on hands
+/mob/living/proc/drop_both_hands()
+	if(l_hand)
+		unEquip(l_hand)
+	if(r_hand)
+		unEquip(r_hand)
+	return
+// CHOMPEnd
+
 /mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/target = null)
 	return !(W in internal_organs) && ..()
 
@@ -935,17 +944,42 @@
 			lying = incapacitated(INCAPACITATION_KNOCKDOWN)
 			canmove = !incapacitated(INCAPACITATION_DISABLED)
 
+	if(lying && (incapacitated(INCAPACITATION_KNOCKOUT) || incapacitated(INCAPACITATION_STUNNED))) // CHOMPAdd - Making sure we're in good condition to crawl
+		canmove = 0
+		drop_both_hands()
+	else
+		canmove = 1
 	if(lying)
 		density = FALSE
+		/* CHOMPEdit - Allow us to hold stuff while laying down.
 		if(l_hand)
 			unEquip(l_hand)
 		if(r_hand)
 			unEquip(r_hand)
 		for(var/obj/item/weapon/holder/holder in get_mob_riding_slots())
 			unEquip(holder)
+		*/
 		update_water() // Submerges the mob.
+		// CHOMPAdd Start - For crawling.
+		stop_pulling()
+
+		if(!passtable_crawl_checked)
+			passtable_crawl_checked = TRUE
+			if(pass_flags & PASSTABLE)
+				passtable_reset = FALSE
+			else
+				passtable_reset = TRUE
+				pass_flags |= PASSTABLE
+
+		// CHOMPEdit End
 	else
 		density = initial(density)
+	// CHOMPEdit Start - Rest passtable when crawling
+		if(passtable_reset)
+			passtable_reset = TRUE
+			pass_flags &= ~PASSTABLE
+		passtable_crawl_checked = FALSE
+	// CHOMPEdit End
 
 	for(var/obj/item/weapon/grab/G in grabbed_by)
 		if(G.state >= GRAB_AGGRESSIVE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -946,7 +946,7 @@
 
 	if(lying && (incapacitated(INCAPACITATION_KNOCKOUT) || incapacitated(INCAPACITATION_STUNNED))) // CHOMPAdd - Making sure we're in good condition to crawl
 		canmove = 0
-		drop_both_hands()
+		//drop_both_hands() CHOMPremove, purple stuns dont drop items, this makes space EVA less frustrating and slips/shoves are already coded to drop your stuff.
 	else
 		canmove = 1
 	if(lying)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -963,22 +963,24 @@
 		//RS Port Chomp PR 7822 || CHOMPAdd Start - For crawling.
 		stop_pulling()
 
-		if(!passtable_crawl_checked)
+		/*if(!passtable_crawl_checked)
 			passtable_crawl_checked = TRUE
 			if(pass_flags & PASSTABLE)
 				passtable_reset = FALSE
 			else
 				passtable_reset = TRUE
 				pass_flags |= PASSTABLE
-
+		*/ //Commented out on request by maintainers
 		//RS Port Chomp PR 7822 || CHOMPEdit End
 	else
 		density = initial(density)
 	//RS Port Chomp PR 7822 || CHOMPEdit Start - Rest passtable when crawling
+	/*
 		if(passtable_reset)
 			passtable_reset = TRUE
 			pass_flags &= ~PASSTABLE
 		passtable_crawl_checked = FALSE
+	*/ //Commented out on request by maintainers
 	//RS Port Chomp PR 7822 || CHOMPEdit End
 
 	for(var/obj/item/weapon/grab/G in grabbed_by)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -808,14 +808,14 @@
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return 0
 
-// CHOMPAdd - Drop both things on hands
+//RS Port Chomp PR 7822 || CHOMPAdd - Drop both things on hands
 /mob/living/proc/drop_both_hands()
 	if(l_hand)
 		unEquip(l_hand)
 	if(r_hand)
 		unEquip(r_hand)
 	return
-// CHOMPEnd
+//RS Port Chomp PR 7822 || CHOMPEnd
 
 /mob/living/carbon/drop_from_inventory(var/obj/item/W, var/atom/target = null)
 	return !(W in internal_organs) && ..()
@@ -944,14 +944,14 @@
 			lying = incapacitated(INCAPACITATION_KNOCKDOWN)
 			canmove = !incapacitated(INCAPACITATION_DISABLED)
 
-	if(lying && (incapacitated(INCAPACITATION_KNOCKOUT) || incapacitated(INCAPACITATION_STUNNED))) // CHOMPAdd - Making sure we're in good condition to crawl
+	if(lying && (incapacitated(INCAPACITATION_KNOCKOUT) || incapacitated(INCAPACITATION_STUNNED))) //RS Port Chomp PR 7822 || CHOMPAdd - Making sure we're in good condition to crawl
 		canmove = 0
-		//drop_both_hands() CHOMPremove, purple stuns dont drop items, this makes space EVA less frustrating and slips/shoves are already coded to drop your stuff.
+		//RS Port Chomp PR 8154 || drop_both_hands() CHOMPremove, purple stuns dont drop items, this makes space EVA less frustrating and slips/shoves are already coded to drop your stuff.
 	else
 		canmove = 1
 	if(lying)
 		density = FALSE
-		/* CHOMPEdit - Allow us to hold stuff while laying down.
+		/* //RS Port Chomp PR 7822 || CHOMPEdit - Allow us to hold stuff while laying down.
 		if(l_hand)
 			unEquip(l_hand)
 		if(r_hand)
@@ -960,7 +960,7 @@
 			unEquip(holder)
 		*/
 		update_water() // Submerges the mob.
-		// CHOMPAdd Start - For crawling.
+		//RS Port Chomp PR 7822 || CHOMPAdd Start - For crawling.
 		stop_pulling()
 
 		if(!passtable_crawl_checked)
@@ -971,15 +971,15 @@
 				passtable_reset = TRUE
 				pass_flags |= PASSTABLE
 
-		// CHOMPEdit End
+		//RS Port Chomp PR 7822 || CHOMPEdit End
 	else
 		density = initial(density)
-	// CHOMPEdit Start - Rest passtable when crawling
+	//RS Port Chomp PR 7822 || CHOMPEdit Start - Rest passtable when crawling
 		if(passtable_reset)
 			passtable_reset = TRUE
 			pass_flags &= ~PASSTABLE
 		passtable_crawl_checked = FALSE
-	// CHOMPEdit End
+	//RS Port Chomp PR 7822 || CHOMPEdit End
 
 	for(var/obj/item/weapon/grab/G in grabbed_by)
 		if(G.state >= GRAB_AGGRESSIVE)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -306,8 +306,8 @@
 				playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
 			var/mob/living/carbon/human/H = target
 			if(H.species.lightweight == 1)
-				H.Stun(3) // CHOMPEdit - Crawling made this useless. Changing to stun instead.
-				H.drop_both_hands() //Chopmedit - Stuns no longer drop items, so were forcing it >:3
+				H.Stun(3) //RS Port Chomp PR 8154 || CHOMPEdit - Crawling made this useless. Changing to stun instead.
+				H.drop_both_hands() //RS Port Chomp PR 8154 || Chopmedit - Stuns no longer drop items, so were forcing it >:3
 	return
 
 /obj/item/pupscrubber
@@ -464,12 +464,12 @@
 		var/mob/living/carbon/human/H = T
 		if(H.species.lightweight == 1)
 			//H.Weaken(3)
-			H.Stun(3) //CHOMPEdit - Crawling made this useless. Changing to stun instead.
+			H.Stun(3) //RS Port Chomp PR 8047 || CHOMPEdit - Crawling made this useless. Changing to stun instead.
 			H.drop_both_hands() //Chopmedit - Stuns no longer drop items, so were forcing it >:3
 			return
 	var/armor_block = run_armor_check(T, "melee")
 	var/armor_soak = get_armor_soak(T, "melee")
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
 	if(prob(75)) //75% chance to stun for 5 seconds, really only going to be 4 bcus click cooldown+animation.
-		//T.apply_effect(5, WEAKEN, armor_block) // Chomp edit
+		//T.apply_effect(5, WEAKEN, armor_block) //RS Port Chomp PR 8047 || Chomp edit
 		T.apply_effect(5, STUN, armor_block)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -306,7 +306,8 @@
 				playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
 			var/mob/living/carbon/human/H = target
 			if(H.species.lightweight == 1)
-				H.Weaken(3)
+				H.Stun(3) // CHOMPEdit - Crawling made this useless. Changing to stun instead.
+				H.drop_both_hands() //Chopmedit - Stuns no longer drop items, so were forcing it >:3
 	return
 
 /obj/item/pupscrubber
@@ -462,10 +463,13 @@
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
 		if(H.species.lightweight == 1)
-			H.Weaken(3)
+			//H.Weaken(3)
+			H.Stun(3) //CHOMPEdit - Crawling made this useless. Changing to stun instead.
+			H.drop_both_hands() //Chopmedit - Stuns no longer drop items, so were forcing it >:3
 			return
 	var/armor_block = run_armor_check(T, "melee")
 	var/armor_soak = get_armor_soak(T, "melee")
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
 	if(prob(75)) //75% chance to stun for 5 seconds, really only going to be 4 bcus click cooldown+animation.
-		T.apply_effect(5, WEAKEN, armor_block)
+		//T.apply_effect(5, WEAKEN, armor_block) // Chomp edit
+		T.apply_effect(5, STUN, armor_block)

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -144,7 +144,7 @@
 
 		// We're not attempting a pounce, if they're down or we can eat standing, do it as long as they're edible. Otherwise, hit normally.
 		//if(will_eat(L) && (!L.canmove || vore_standing_too))
-		if(will_eat(L) && (L.lying || vore_standing_too)) //CHOMPEdit
+		if(will_eat(L) && (L.lying || vore_standing_too)) //RS Port Chomp PR 7900 || CHOMPEdit
 			return EatTarget(L)
 		else
 			return ..()
@@ -176,7 +176,7 @@
 		playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
 	//if(will_eat(M) && (!M.canmove || vore_standing_too)) //if they're edible then eat them too
-	if(will_eat(M) && (M.lying || vore_standing_too)) //if they're edible then eat them too //CHOMPEdit Crawling compat
+	if(will_eat(M) && (M.lying || vore_standing_too)) //if they're edible then eat them too //RS Port Chomp PR 7900 || CHOMPEdit Crawling compat
 		return EatTarget(M)
 	else
 		return //just leave them

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -143,7 +143,8 @@
 			return PounceTarget(L, pouncechance)
 
 		// We're not attempting a pounce, if they're down or we can eat standing, do it as long as they're edible. Otherwise, hit normally.
-		if(will_eat(L) && (!L.canmove || vore_standing_too))
+		//if(will_eat(L) && (!L.canmove || vore_standing_too))
+		if(will_eat(L) && (L.lying || vore_standing_too)) //CHOMPEdit
 			return EatTarget(L)
 		else
 			return ..()
@@ -174,7 +175,8 @@
 		M.visible_message("<span class='danger'>\The [src] attempts to pounce \the [M] but misses!</span>!")
 		playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
-	if(will_eat(M) && (!M.canmove || vore_standing_too)) //if they're edible then eat them too
+	//if(will_eat(M) && (!M.canmove || vore_standing_too)) //if they're edible then eat them too
+	if(will_eat(M) && (M.lying || vore_standing_too)) //if they're edible then eat them too //CHOMPEdit Crawling compat
 		return EatTarget(M)
 	else
 		return //just leave them
@@ -186,6 +188,7 @@
 	//stop_automated_movement = 1 //VORESTATION AI TEMPORARY REMOVAL
 	var/old_target = M
 	set_AI_busy(1) //VORESTATION AI TEMPORARY EDIT
+	M.Stun(3) //RSEdit - Crawling made this useless. added stun instead.
 	. = animal_nom(M)
 	playsound(src, swallowsound, 50, 1)
 	update_icon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -544,7 +544,7 @@
 	if (AM.anchored)
 		to_chat(src, "<span class='warning'>It won't budge!</span>")
 		return
-	if(lying) // CHOMPAdd - No pulling while we crawl.
+	if(lying) //RS Port Chomp PR 7822 || CHOMPAdd - No pulling while we crawl.
 		return
 	var/mob/M = AM
 	if(ismob(AM))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -544,7 +544,8 @@
 	if (AM.anchored)
 		to_chat(src, "<span class='warning'>It won't budge!</span>")
 		return
-
+	if(lying) // CHOMPAdd - No pulling while we crawl.
+		return
 	var/mob/M = AM
 	if(ismob(AM))
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -15,7 +15,7 @@
 		if(weakened >= 1)
 			. += 14			// Very slow when weakened.
 		else
-			. += 8
+			. += 5 //slowed down on maintainer request
 	//RS Port Chomp PR 7822 || CHOMPAdd End
 
 	// Movespeed delay based on movement mode

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -10,6 +10,13 @@
 	. = 0
 	if(locate(/obj/item/weapon/grab) in src)
 		. += 5
+	// CHOMPAdd Start - When crawling, move slow.
+	if(lying)
+		if(weakened >= 1)
+			. += 14			// Very slow when weakened.
+		else
+			. += 8
+	// CHOMPAdd End
 
 	// Movespeed delay based on movement mode
 	switch(m_intent)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -10,13 +10,13 @@
 	. = 0
 	if(locate(/obj/item/weapon/grab) in src)
 		. += 5
-	// CHOMPAdd Start - When crawling, move slow.
+	//RS Port Chomp PR 7822 || CHOMPAdd Start - When crawling, move slow.
 	if(lying)
 		if(weakened >= 1)
 			. += 14			// Very slow when weakened.
 		else
 			. += 8
-	// CHOMPAdd End
+	//RS Port Chomp PR 7822 || CHOMPAdd End
 
 	// Movespeed delay based on movement mode
 	switch(m_intent)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -27,8 +27,8 @@
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
 	var/trash_catching = FALSE 			//RSEdit: Toggle for trash throw vore || Ports trash eater throw vore from CHOMPStation PR#5987
-	var/passtable_reset					//CHOMPEDIT For crawling
-	var/passtable_crawl_checked = FALSE //CHOMPEDIT For Crawling
+	var/passtable_reset					//RS Port Chomp PR 7822 || CHOMPEDIT For crawling
+	var/passtable_crawl_checked = FALSE //RS Port Chomp PR 7822 || CHOMPEDIT For Crawling
 
 	var/list/trait_injection_reagents = list() 	//RSEdit: Reagents available from injection traits
 	var/trait_injection_selected = null			//RSEdit: What trait reagent you're injecting.

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -27,6 +27,9 @@
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
 	var/trash_catching = FALSE 			//RSEdit: Toggle for trash throw vore || Ports trash eater throw vore from CHOMPStation PR#5987
+	var/passtable_reset					//CHOMPEDIT For crawling
+	var/passtable_crawl_checked = FALSE //CHOMPEDIT For Crawling
+
 	var/list/trait_injection_reagents = list() 	//RSEdit: Reagents available from injection traits
 	var/trait_injection_selected = null			//RSEdit: What trait reagent you're injecting.
 	var/trait_injection_amount = 5				//RSEdit: How much you're injecting with traits.

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -27,8 +27,9 @@
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
 	var/trash_catching = FALSE 			//RSEdit: Toggle for trash throw vore || Ports trash eater throw vore from CHOMPStation PR#5987
-	var/passtable_reset					//RS Port Chomp PR 7822 || CHOMPEDIT For crawling
-	var/passtable_crawl_checked = FALSE //RS Port Chomp PR 7822 || CHOMPEDIT For Crawling
+	//Commented out by maintainer request
+	//var/passtable_reset					//RS Port Chomp PR 7822 || CHOMPEDIT For crawling
+	//var/passtable_crawl_checked = FALSE //RS Port Chomp PR 7822 || CHOMPEDIT For Crawling
 
 	var/list/trait_injection_reagents = list() 	//RSEdit: Reagents available from injection traits
 	var/trait_injection_selected = null			//RSEdit: What trait reagent you're injecting.


### PR DESCRIPTION
Original: https://github.com/TS-Rogue-Star/Rogue-Star/pull/451

Ports chompstation crawling - https://github.com/CHOMPStation2/CHOMPStation2/pull/7822
With these fixes:
https://github.com/CHOMPStation2/CHOMPStation2/pull/8154
https://github.com/CHOMPStation2/CHOMPStation2/pull/8047
https://github.com/CHOMPStation2/CHOMPStation2/pull/7900

(and added a stun(3) to simple mob vore sequence)

Concerns with current implementation:
Rest crawling to bypass tables feels cheaty compared to dragging your sprite atop of, but I'm leaving that up to project leads
(its easy to turn it off)