### PR TITLE
Buildable optable (reup)

### DIFF
--- a/code/datums/supplypacks/medical_vr.dm
+++ b/code/datums/supplypacks/medical_vr.dm
@@ -52,9 +52,6 @@
 	containername = "Compact Defibrillator crate"
 	access = access_medical_equip
 
-	/datum/supply_pack/med/bloodpack
-	containertype = /obj/structure/closet/crate/medical/blood
-
 /datum/supply_pack/med/optable
 	name = "Operating Table Circuit crate"
 	contains = list(

--- a/code/datums/supplypacks/medical_vr.dm
+++ b/code/datums/supplypacks/medical_vr.dm
@@ -52,6 +52,7 @@
 	containername = "Compact Defibrillator crate"
 	access = access_medical_equip
 
+//RS add Buildable Optable
 /datum/supply_pack/med/optable
 	name = "Operating Table Circuit crate"
 	contains = list(
@@ -62,3 +63,4 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "Operating Table Circuit crate"
 	access = access_medical_equip
+//Rs add end

--- a/code/datums/supplypacks/medical_vr.dm
+++ b/code/datums/supplypacks/medical_vr.dm
@@ -51,3 +51,17 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "Compact Defibrillator crate"
 	access = access_medical_equip
+
+	/datum/supply_pack/med/bloodpack
+	containertype = /obj/structure/closet/crate/medical/blood
+
+/datum/supply_pack/med/optable
+	name = "Operating Table Circuit crate"
+	contains = list(
+				/obj/item/weapon/circuitboard/op_table = 2,
+				/obj/item/weapon/circuitboard/operating  = 2
+				)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Operating Table Circuit crate"
+	access = access_medical_equip

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	unacidable = TRUE
+	circuit = /obj/item/weapon/circuitboard/op_table //RS Add (make optable buildable)
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 1
 	active_power_usage = 5
@@ -15,6 +16,13 @@
 	var/strapped = 0.0
 	var/obj/machinery/computer/operating/computer = null
 
+//RS add (make optable buildable)
+/obj/machinery/optable/Initialize()
+    . = ..()
+    if(ispath(circuit))
+        circuit = new circuit(src)
+    default_apply_parts()
+//RS add End (make optable buildable)
 /obj/machinery/optable/New()
 	..()
 	for(var/direction in list(NORTH,EAST,SOUTH,WEST))
@@ -124,6 +132,13 @@
 			take_victim(G.affecting, user)
 			qdel(W)
 			return
+	//RS Add (buildable optable)
+	if(!victim)
+		if(default_deconstruction_screwdriver(user, W))
+			return
+		if(default_deconstruction_crowbar(user, W))
+			return
+	//RS Add End (buildable optable)
 
 /obj/machinery/optable/proc/check_table(mob/living/carbon/patient, mob/living/user)
 	check_victim()

--- a/code/game/objects/items/weapons/circuitboards/frame.dm
+++ b/code/game/objects/items/weapons/circuitboards/frame.dm
@@ -209,7 +209,16 @@
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 3,
 							/obj/item/stack/material/glass/reinforced = 2)
-
+//RS Add (buildable optable)
+/obj/item/weapon/circuitboard/op_table
+	name = T_BOARD("operating table")
+	build_path = /obj/machinery/optable
+	board_type = new /datum/frame/frame_types/medical_pod
+	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	req_components = list(
+							/obj/item/stack/material/titanium = 5,
+							/obj/item/stack/material/silver = 5)
+//RS Add End (buildable optable)
 /obj/item/weapon/circuitboard/medical_kiosk
 	name = T_BOARD("medical kiosk")
 	build_path = /obj/machinery/medical_kiosk


### PR DESCRIPTION
Original: https://github.com/TS-Rogue-Star/Rogue-Star/pull/431

You can now order circuits to build operating tables and their patient monitors from cargo.
You can now assembled and dissemble operating tables that exist.

Costs:
5x Steel (Medical Pod Frame)
5x Cable Coil
1x Operating Table Circuit Board
5x Titanium Sheets
5x Silver Sheets

