### PR TITLE
radiantAurora marking fixes & attributions

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -121,3 +121,21 @@
 **Creator:** radiantAurora (https://github.com/radiantAurora)<br>
 **License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
 <br>
+<br>
+**File:** `icons/mob/human_races/markings_alt.dmi`<br>
+**Title:** vulp_skull-head, una_skull-head, bellyspiral, fluffy_cuffs, chubby_belly, chubby_belly_s, belly_fluff, chest_fluff, teshari_skull-head, shoulder_markings<br>
+**Creator:** radiantAurora (https://github.com/radiantAurora)<br>
+**License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
+<br>
+<br>
+**File:** `icons/mob/human_races/markings_vr.dmi`<br>
+**Title:** beestripes<br>
+**Creator:** radiantAurora (https://github.com/radiantAurora)<br>
+**License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
+<br>
+<br>
+**File:** `icons/mob/human_races/sprite_accessories/ears.dmi`<br>
+**Title:** wild_dog<br>
+**Creator:** radiantAurora (https://github.com/radiantAurora)<br>
+**License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
+<br>

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -121,18 +121,15 @@
 **Creator:** radiantAurora (https://github.com/radiantAurora)<br>
 **License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
 <br>
-<br>
 **File:** `icons/mob/human_races/markings_alt.dmi`<br>
 **Title:** vulp_skull-head, una_skull-head, bellyspiral, fluffy_cuffs, chubby_belly, chubby_belly_s, belly_fluff, chest_fluff, teshari_skull-head, shoulder_markings<br>
 **Creator:** radiantAurora (https://github.com/radiantAurora)<br>
 **License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
 <br>
-<br>
 **File:** `icons/mob/human_races/markings_vr.dmi`<br>
 **Title:** beestripes<br>
 **Creator:** radiantAurora (https://github.com/radiantAurora)<br>
 **License:** [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)<br>
-<br>
 <br>
 **File:** `icons/mob/human_races/sprite_accessories/ears.dmi`<br>
 **Title:** wild_dog<br>

--- a/code/modules/mob/new_player/sprite_markings/markings_body.dm
+++ b/code/modules/mob/new_player/sprite_markings/markings_body.dm
@@ -52,6 +52,7 @@
 
 /datum/sprite_accessory/marking/vr_bellyspiral
 	name = "Belly Spiral"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "bellyspiral"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_TORSO,BP_GROIN)
@@ -59,6 +60,7 @@
 
 /datum/sprite_accessory/marking/vr_fluffy_cuffs
 	name = "Wrist Fluff"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "fluffy_cuffs"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND)
@@ -66,6 +68,7 @@
 
 /datum/sprite_accessory/marking/vr_chubby_belly
 	name = "Chubby Belly"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "chubby_belly"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_TORSO,BP_GROIN)
@@ -73,6 +76,7 @@
 
 /datum/sprite_accessory/marking/vr_chubby_belly_s
 	name = "Smooth Chubby Belly"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "chubby_belly_s"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_TORSO,BP_GROIN)
@@ -80,6 +84,7 @@
 
 /datum/sprite_accessory/marking/vr_r_belly_fluff
 	name = "Belly Fluff"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "belly_fluff"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_TORSO)
@@ -87,6 +92,7 @@
 
 /datum/sprite_accessory/marking/vr_r_chest_fluff
 	name = "Chest Fluff"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "chest_fluff"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_TORSO)
@@ -94,6 +100,7 @@
 
 /datum/sprite_accessory/marking/vr_shoulder_fluff
 	name = "Shoulder Fluff"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "shoulder_markings"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_L_ARM,BP_R_ARM)

--- a/code/modules/mob/new_player/sprite_markings/markings_head.dm
+++ b/code/modules/mob/new_player/sprite_markings/markings_head.dm
@@ -495,6 +495,7 @@
 
 /datum/sprite_accessory/marking/vr/una_skull
 	name = "Unathi Skull Face"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "una_skull"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_HEAD)
@@ -519,6 +520,7 @@
 /***	Vulp based	***/
 /datum/sprite_accessory/marking/vr/vulp_skull
 	name = "Vulpkanin Skull Face"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "vulp_skull"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_HEAD)

--- a/code/modules/mob/new_player/sprite_markings/markings_head.dm
+++ b/code/modules/mob/new_player/sprite_markings/markings_head.dm
@@ -499,6 +499,7 @@
 	icon_state = "una_skull"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_HEAD)
+	sorting_group = MARKINGS_HEAD
 
 /datum/sprite_accessory/marking/vr_unathi_blocky_head
 	name = "Unathi alt head (Blocky)"
@@ -524,6 +525,7 @@
 	icon_state = "vulp_skull"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_HEAD)
+	sorting_group = MARKINGS_HEAD
 
 /datum/sprite_accessory/marking/vr_vulp_nose
 	name = "nose (Vulp)"

--- a/code/modules/mob/new_player/sprite_markings/markings_teshari.dm
+++ b/code/modules/mob/new_player/sprite_markings/markings_teshari.dm
@@ -532,6 +532,7 @@
 /***	Markings	***/
 /datum/sprite_accessory/marking/vr_tesh_skull
 	name = "Teshari Skull Face"
+	icon = 'icons/mob/human_races/markings_alt.dmi'
 	icon_state = "teshari_skull"
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_HEAD)


### PR DESCRIPTION
Fixes a variety of markings created by myself that predate Rogue Star by linking to the correct file, also adds attributions for said markings.