### PR TITLE
Changes settings file to enable dmi editor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "**/.pnp.*": true
     },
     "workbench.editorAssociations": {
-        "*.dmi": "imagePreview.previewEditor"
+        "*.dmi": "dmiEditor.dmiEditor"
     },
     "files.eol": "\n",
     "files.encoding": "utf8",


### PR DESCRIPTION
Simple as, lets you use the inbuilt DMI editor in VScode by enabling the setting.