### PR TITLE
Removes Osteodaxon from Leapardmanders

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -989,7 +989,7 @@ I think I covered everything.
 				//Alternatively bully a coder (me) to make a unique digest_mode for mob healbellies that prevents death, or something.
 				if(istype(A, /mob/living/carbon/human))
 					var/mob/living/carbon/human/P = L
-					var/list/to_inject = list("myelamine","spaceacillin","peridaxon", "iron", "hyronalin") // RS Edit, removing Osteo since healbellies already fix broken bones.
+					var/list/to_inject = list("myelamine","spaceacillin","peridaxon", "iron", "hyronalin") // RS Edit, removing Osteo as bone breaks won't kill you.
 					//Lets not OD them...
 					for(var/RG in to_inject)
 						if(!P.reagents.has_reagent(RG))

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -989,7 +989,7 @@ I think I covered everything.
 				//Alternatively bully a coder (me) to make a unique digest_mode for mob healbellies that prevents death, or something.
 				if(istype(A, /mob/living/carbon/human))
 					var/mob/living/carbon/human/P = L
-					var/list/to_inject = list("myelamine","osteodaxon","spaceacillin","peridaxon", "iron", "hyronalin")
+					var/list/to_inject = list("myelamine","spaceacillin","peridaxon", "iron", "hyronalin") // RS Edit, removing Osteo since healbellies already fix broken bones.
 					//Lets not OD them...
 					for(var/RG in to_inject)
 						if(!P.reagents.has_reagent(RG))


### PR DESCRIPTION
Currently the AI Holder for healbelly mobs such as leapardmanders injects the following chems upon grabbing an injured person.

- Myelamine
- Osteodaxon
- Spaceacillin
- Peridaxon
- Iron
- Hyronalin

According to the comments, the intent for this feature is to prevent a patient from dying in the belly.

This PR removes osteodaxon from the list of chems, as ~~the bone fixing functionality is duplicated in healbelly code at this time with it's own balancing.~~ Actually isn't duplicated from what I can tell, but it's still overkill for stabilization.

The rest of the chems remain, as to preserve the intended functionality of stabilizing a patient. The only other chem that's mildly suspect is myelamine, but with as punishing as internal bleeds are currently removing it from the mix would be a net negative in my opinion.