### PR TITLE
Fixes Slippery Holders

### DIFF
--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -1,9 +1,18 @@
+/*
+	RS Edit Start, Fix ported from ChompStation for mob holders floppin.
 /obj/item/weapon/holder/dropped(mob/user)
 	if (held_mob?.loc != src || isturf(loc))
 		var/held = held_mob
+		log_and_message_admins("Dropping holder!")
 		dump_mob()
 		held_mob = held
-
+*/
+/obj/item/weapon/holder/dropped(mob/user)
+	..()
+	spawn(1)
+		if(!throwing && isturf(loc))
+			qdel(src)
+// RS Edit/ChompPort End
 /obj/item/weapon/holder/attack_hand(mob/living/user as mob) //straight up just copypasted from objects/items.dm with a few things changed (doesn't called dropped unless +actually dropped+)
 	if (!user) return
 	if(anchored)

--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -3,7 +3,6 @@
 /obj/item/weapon/holder/dropped(mob/user)
 	if (held_mob?.loc != src || isturf(loc))
 		var/held = held_mob
-		log_and_message_admins("Dropping holder!")
 		dump_mob()
 		held_mob = held
 */

--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -1,5 +1,6 @@
 /*
 	RS Edit Start, Fix ported from ChompStation for mob holders floppin.
+	Code for this Edit was written by Verkister
 /obj/item/weapon/holder/dropped(mob/user)
 	if (held_mob?.loc != src || isturf(loc))
 		var/held = held_mob


### PR DESCRIPTION
Previously, holders would drop to the ground when handing a micro to another player, placing them in disposals, or placing them into an oven.

This fixes that behavior.

Code for the fix was sent to me by @crossexonar, written by @Verkister on chomp.

PR From Chomp: https://github.com/CHOMPStation2/CHOMPStation2/pull/6091