### PR TITLE
Ports Venomous Injection

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1555,8 +1555,9 @@
 
 	choices += "Change amount"
 	choices += "Change verb"
+	choices += "Chemical refresher"
 
-	var/choice = tgui_alert(src, "Do you wish to inject somebody, or adjust settings?", "Selection List", choices)
+	var/choice = tgui_alert(src, "Do you wish to inject somebody or adjust settings?", "Selection List", choices)
 
 	if(choice == "Change reagent")
 		var/reagent_choice = tgui_input_list(usr, "Choose which reagent to inject!", "Select reagent", trait_injection_reagents)
@@ -1576,15 +1577,48 @@
 			trait_injection_verb = verb_choice
 		to_chat(src, "<span class='notice'>You will [trait_injection_verb] your targets.</span>")
 		return
+	if(choice == "Chemical Refresher")
+		var/output = {"<B>Chemical Refresher!</B><HR>
+					<B>Options for venoms</B><BR>
+					<BR>
+					<B>Size Chemicals</B><BR>
+					Microcillin: Will make someone shrink. <br>
+					Macrocillin: Will make someone grow. <br>
+					Normalcillin: Will make someone normal size. <br>
+					Note: 1 unit = 100% size diff. 0.01 unit = 1% size diff. <br>
+					Note: Normacillin stops at 100%  size. <br>
+					<br>
+					<B>Gender Chemicals</B><BR>
+					Androrovir: Will transform someone's sex to male. <br>
+					Gynorovir: Will transform someone's sex to female. <br>
+					Androgynorovir: Will transform someone's sex to plural. <br>
+					<br>
+					<B>Special Chemicals</B><BR>
+					Stoxin: Will make someone drowsy. <br>
+					Rainbow Toxin: Will make someone see rainbows. <br>
+					Paralysis Toxin: Will make someone paralyzed. <br>
+					Numbing Enzyme: Will make someone unable to feel pain. <br>
+					Pain Enzyme: Will make someone feel amplified pain. <br>
+					<br>
+					<B>Side Notes</B><BR>
+					You can select a value of 0 to inject nothing! <br>
+					Overdose threshold for most chemicals is 30 units. <br>
+					Exceptions to OD is: (Numbing Enzyme:20)<br>
+					You can also bite synthetics, but due to how synths work, they won't have anything injected into them.
+					<br>
+					"}
+		usr << browse(output,"window=chemicalrefresher")
+		return
 	else
 		var/list/targets = list() //IF IT IS NOT BROKEN. DO NOT FIX IT. AND KEEP COPYPASTING IT
-
 		for(var/mob/living/carbon/L in living_mobs(1, TRUE)) //Noncarbons don't even process reagents so don't bother listing others.
 			if(!istype(L, /mob/living/carbon))
 				continue
 			if(L == src) //no getting high off your own supply, get a nif or something, nerd.
 				continue
 			if(!L.resizable && (trait_injection_selected == "macrocillin" || trait_injection_selected == "microcillin" || trait_injection_selected == "normalcillin")) // If you're using a size reagent, ignore those with pref conflicts.
+				continue
+			if(!L.allow_spontaneous_tf && (trait_injection_selected == "androrovir" || trait_injection_selected == "gynorovir" || trait_injection_selected == "androgynorovir")) // If you're using a TF reagent, ignore those with pref conflicts. || Ports VOREStation PR16060
 				continue
 			targets += L
 
@@ -1613,7 +1647,7 @@
 			to_chat(src, "<span class='notice'>Somehow, you forgot your means of injecting. (Select a verb!)</span>")
 			return
 
-		if(do_after(src, 5, target))
+		if(do_after(src, 50, target))
 			add_attack_logs(src,target,"Injection trait ([trait_injection_selected], [trait_injection_amount])")
 			if(target.reagents)
 				target.reagents.add_reagent(trait_injection_selected, trait_injection_amount)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1016,3 +1016,44 @@
 	var_changes = list("digest_pain" = FALSE)
 	custom_only = FALSE
 	can_take = ORGANICS
+
+//RS Edit || Ports VOREStation PR16060
+/datum/trait/neutral/venom_bite
+	name = "Venomous Injection"
+	desc = "Allows for injecting prey through one method or another to inject them with a variety of chemicals with varying effects!"
+	tutorial = "This trait allows you to bite prey with varying effects! <br> \
+		Options for venoms: <br> \
+		=====Size Chemicals ===== <br> \
+		Microcillin: Will make someone shrink. (This is 1% per 0.01 units. So 1 unit = 100% size change) <br> \
+		Macrocillin: Will make someone grow. (This is 1% per 0.01 units. So 1 unit = 100% size change) <br> \
+		Normalcillin: Will make someone normal size. (This is 1% per 0.01 units. So 1 unit = 100% size change) Stops at 100% size. <br> \
+		===== Gender Chemicals ===== <br> \
+		Androrovir: Will transform someone's sex to male. <br> \
+		Gynorovir: Will transform someone's sex to female. <br> \
+		Androgynorovir: Will transform someone's sex to pleural. <br> \
+		===== Special Chemicals ===== <br> \
+		Stoxin: Will make someone drowsy. <br> \
+		Rainbow Toxin: Will make someone see rainbows. <br> \
+		Paralysis Toxin: Will make someone paralyzed. <br> \
+		Numbing Enzyme: Will make someone unable to feel pain. <br> \
+		Pain Enzyme: Will make someone feel pain, amplifieed <br> \
+		===== Side Notes ===== <br> \
+		You aren't required to inject anything if you prefer to just use it as a normal bite!"
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/venom_bite/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/proc/injection
+	H.trait_injection_reagents += "microcillin"		// get small
+	H.trait_injection_reagents += "macrocillin"		// get BIG
+	H.trait_injection_reagents += "normalcillin"	// normal
+	H.trait_injection_reagents += "numbenzyme"		// no feelings
+	H.trait_injection_reagents += "androrovir" 		// -> MALE
+	H.trait_injection_reagents += "gynorovir" 		// -> FEMALE
+	H.trait_injection_reagents += "androgynorovir" 	// -> PLURAL
+	H.trait_injection_reagents += "stoxin"			// night night chem
+	H.trait_injection_reagents += "rainbowtoxin" 	// Funny flashing lights.
+	H.trait_injection_reagents += "paralysistoxin" 	// Paralysis!
+	H.trait_injection_reagents += "painenzyme"		// Pain INCREASER
+//RS Edit end

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -74,7 +74,7 @@
 */
 
 //RS ADD START
-
+/*
 /datum/trait/positive/shrinkinject
 	name = "Venom: Microcillin"
 	desc = "Provides the ability to inject a shrinking chemical into others, through a bite, or sting, or however else."
@@ -171,6 +171,7 @@
 	H.trait_injection_reagents += "normalcillin"
 
 //RS ADD END
+*/
 
 /datum/trait/positive/minor_brute_resist
 	name = "Brute Resist, Minor"

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -365,3 +365,58 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 //Can do conversions here
 /datum/vore_preferences/proc/patch_version(var/list/json_from_file,var/version)
 	return json_from_file
+
+////////////////////////// Misc Drugs //////////////////////////
+
+/datum/reagent/drugs/rainbow_toxin /// Replaces Space Drugs.
+	name = "Rainbow Toxin"
+	id = "rainbowtoxin"
+	description = "Known for providing a euphoric high, this psychoactive drug is often injected into unknowing prey by serpents and other fanged beasts. Highly valuable and frequently sought after by hypno-enthusiasts and party-goers."
+	taste_description = "mixed euphoria"
+	taste_mult = 0.8 //You ARE going to taste this!
+	scannable = 1	//Sure! If you manage to milk a snake for some of this, go ahead and scan it and mass produce it. Your local club will love you!
+
+/datum/reagent/drugs/rainbow_toxin/affect_blood(mob/living/carbon/M, var/alien, var/removed)
+	..()
+	var/drug_strength = 20
+	M.druggy = max(M.druggy, drug_strength)
+
+/datum/reagent/drugs/bliss/overdose(var/mob/living/M as mob)
+	if(prob_proc == TRUE && prob(20))
+		M.hallucination = max(M.hallucination, 5)
+		prob_proc = FALSE
+	M.adjustBrainLoss(0.25*REM) //Too much isn't good for your long term health...
+	M.adjustToxLoss(0.01*REM)	//Enough that it'll make your HUD dummy update, but not enough that you'll vomit mid scene. (Sorry emetophiliacs!)
+	..()
+
+/datum/reagent/paralysis_toxin
+	name = "Tetrodotoxin"
+	id = "paralysistoxin"
+	description = "A potent toxin commonly found in a plethora of species. When exposed to the toxin, causes extreme, paralysis for a prolonged period, with only essential functions of the body being unhindered. Commonly used by covert operatives and used as a crowd control tool."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#37007f"
+	metabolism = REM * 0.25
+	overdose = REAGENTS_OVERDOSE
+	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
+
+/datum/reagent/paralysis_toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.weakened < 50) //Let's not leave them PERMA stuck, after all.
+		M.AdjustWeakened(5) //Stand in for paralyze so you can still talk/emote/see
+
+/datum/reagent/pain_enzyme
+	name = "Pain Enzyme"
+	id = "painenzyme"
+	description = "An enzyme found in a variety of species. When exposed to the toxin, will cause severe, agonizing pain. The effects can last for hours depending on the dose. Only known cure is an equally strong painkiller or dialysis."
+	taste_description = "sourness"
+	reagent_state = LIQUID
+	color = "#04b8fa" //Light blue in honor of Perry.
+	metabolism = 0.1 //Lasts up to 50 seconds if you give 5 units.
+	mrate_static = TRUE
+	overdose = 100 //There is no OD. You already are taking the worst of it.
+	scannable = 0 //Let's not have medical mechs able to make an extremely strong 'I hit you you fall down in agony' chem.
+
+/datum/reagent/pain_enzyme/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_PAINKILLER, -200)
+	if(prob(0.01)) //1 in 10000 chance per tick. Extremely rare.
+		to_chat(M,"<span class='warning'>Your body feels as though it's on fire!</span>")


### PR DESCRIPTION
Ports [VOREStation PR 16060](https://github.com/VOREStation/VOREStation/pull/16060).

Makes the venomous injection bites a neutral trait as opposed to positive, and allows players to choose from a list of chemicals, such as Macro/Micro/Normalcillin, gender shifting chems, hallucinogenics, pain, paralysis or sleep chems.

The refresher verb gives users a quick reference guide to what chems do what, and the amounts they'll need to inject. Each chem has a limit of 5 units per injection.