### PR TITLE
Enables Talon reactor glow

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -222,6 +222,7 @@
 		overheat()
 	else if (overheating > 0)
 		overheating--
+	update_icon()	//for machines with overheat sprites (Talon reactor) to update the fact that they're overheating.
 
 /obj/machinery/power/port_gen/pacman/handleInactive()
 	var/cooling_temperature = 20
@@ -239,6 +240,7 @@
 
 	if(overheating)
 		overheating--
+		update_icon()	//same as UseFuel()'s reason, except if it's inactive it wouldn't be called. this just makes sure it's updated.
 
 /obj/machinery/power/port_gen/pacman/proc/overheat()
 	overheating++

--- a/code/modules/power/port_gen_vr.dm
+++ b/code/modules/power/port_gen_vr.dm
@@ -7,6 +7,31 @@
 	power_gen = 50000 //watts
 	anchored = TRUE
 
+/obj/machinery/power/port_gen/pacman/super/potato/Destroy()
+	. = ..()
+	cut_overlays() // sanity checks
+	set_light(0)
+
+/obj/machinery/power/port_gen/pacman/super/potato/update_icon()
+	cut_overlays()
+	set_light(0)
+	//if there was an unexploded broken state, this is where it would go. + return
+	if(active && !overheating)
+		icon_state = "potatoon"
+		var/mutable_appearance/reactorglow = mutable_appearance(icon, "eggrad", alpha = 90) //v.faint glow for reasons. the reasons being it's producing radiation as per code
+		add_overlay(reactorglow)
+		set_light(l_range = 2, l_power = 2, l_color = "#A8B0F8")
+		return
+	else if(overheating)	//The warp core is overloading, Captain!
+		icon_state = "potatodanger"	//show that it's angry, even when it's off. something something subroutine. Visual feedback!
+		if(active)	//but only glow if it's also still on, since the reaction is ongoing.
+			var/mutable_appearance/reactorglow = mutable_appearance(icon, "eggrad", alpha = 190) //more intense glow, lightings
+			add_overlay(reactorglow)
+			set_light(l_range = 5, l_power = 4, l_color = "#A8B0F8")
+		return
+	else	//off and it isn't angry, so we just vibe as 'off'
+		icon_state = initial(icon_state)
+
 // Circuits for the RTGs below
 /obj/item/weapon/circuitboard/machine/rtg
 	name = T_BOARD("radioisotope TEG")


### PR DESCRIPTION
atomized code from #308

Talon's reactor now glows softly whilst operating.
![8cdccaca646c22c645feeb2ebafa305b](https://github.com/user-attachments/assets/a42e2af0-81e5-40c4-b6b7-aed3211737e9)


Glowing intensifies when still active and overheating. It correctly uses it's 'danger' sprite when this occurs and keeps its danger sprite until sufficiently cooled down, returning to normal afterwards. If inactive, it will no longer glow, however. 
![ea23686a0186f31bd596b431e7601e77](https://github.com/user-attachments/assets/303f1c54-9600-413b-b6aa-379c31e9c19e)


Sprite assets were already present in files, they are simply coded in to function.