### PR TITLE
Blacklists Chem Master and dispensors from eggs

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -838,9 +838,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/egg/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(istype(O,/obj/machinery/microwave))
 		return . = ..()
+	if((istype(O,/obj/machinery/chem_master)) || (istype(O,/obj/machinery/chemical_dispenser)))
+		to_chat(user, span_warning("You can't find a good place to crack it into this machine, maybe try a beaker?"))
+		return
 	if(!(proximity && O.is_open_container()))
 		return
-	to_chat(user, "You crack \the [src] into \the [O].")
+	to_chat(user, span_notice("You crack \the [src] into \the [O]."))
 	reagents.trans_to(O, reagents.total_volume)
 	user.drop_from_inventory(src)
 	qdel(src)
@@ -4617,9 +4620,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/siffruit/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(istype(O,/obj/machinery/microwave))
 		return ..()
+	if((istype(O,/obj/machinery/chem_master)) || (istype(O, /obj/machinery/chemical_dispenser)))
+		to_chat(user, span_warning("You can't find a good place to crack it into this machine, maybe try a beaker?"))
+		return
 	if(!(proximity && O.is_open_container()))
 		return
-	to_chat(user, "<span class='notice'>You tear \the [src]'s sac open, pouring it into \the [O].</span>")
+	to_chat(user, span_notice("You tear \the [src]'s sac open, pouring it into \the [O]."))
 	reagents.trans_to(O, reagents.total_volume)
 	user.drop_from_inventory(src)
 	qdel(src)


### PR DESCRIPTION
fixes #398

Runtime in code/modules/reagents/machinery/chem_master.dm,115: Cannot read null.reagent_list

Cracking an egg or 'pulsing fruit' deletes the item, which causes this runtime for tgui, as tgui needs an item inside the beaker slot in order to get the reagents list.

Please do not stick unauthorized materials into these machines. I don't know why you wouldn't just use a beaker or bowl or something first...

These machines should be blacklisted from accepting anything but glass and associated subtypes but I've been informed that people use these machines in an exploitive fashion to 'clean' carpotoxin from fish meat. As that's a balance issue, I'm not going to bother touching that.