### PR TITLE
Fixes Operating Tables Spitting Their Circuit and Components

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -92,8 +92,12 @@
 		C.client.eye = src
 	C.resting = 1
 	C.loc = src.loc
+	/*	RS Edit, commenting this out as it breaks buildable tables.
+		For the life of me, I cannot think of a reason why this loop was run.
 	for(var/obj/O in src)
 		O.loc = src.loc
+		RS Edit End
+	*/
 	add_fingerprint(user)
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C


### PR DESCRIPTION
For some reason Operating Tables run a loop that drop their contents onto their turf when a person is placed on top of the table. This is undesirable behavior now that they actually have contents.

So, I've commented out the loop to prevent the table from regurgitating it's components and circuit.

From testing this doesn't impact the table's functionality in any way. I have no clue why this loop was run to begin with, as normal conditions before buildable tables had no contents inside of the table in any scenario I'm aware of.

If someone knows of an edge case this loop would actually help let me know and I will uncomment it and add checks for build components.