### PR TITLE
VChat Tweaks

### DIFF
--- a/code/controllers/subsystems/chat.dm
+++ b/code/controllers/subsystems/chat.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(chat)
 			if(!C || !C.chatOutput)
 				continue // No client? No care.
 
-			// Originally we didn't send it to oldchat because why? But, turns out that's
+			// RSEdit: Originally we didn't send it to oldchat because why? But, turns out that's
 			// really the only way to log-as-a-stream to a file in byond, so, we send it both ways.
 			DIRECT_OUTPUT(C, original_message)
 
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(chat)
 		if(!C || !C.chatOutput)
 			return // No client? No care.
 
-		DIRECT_OUTPUT(C, original_message)
+		DIRECT_OUTPUT(C, original_message) // RSEdit - Moved this up from the branch below
 
 		if(C.chatOutput.broken || !C.chatOutput.loaded)
 			return // If not loaded yet, do nothing and history-sending on load will get it.

--- a/code/controllers/subsystems/chat.dm
+++ b/code/controllers/subsystems/chat.dm
@@ -59,10 +59,8 @@ SUBSYSTEM_DEF(chat)
 			// really the only way to log-as-a-stream to a file in byond, so, we send it both ways.
 			DIRECT_OUTPUT(C, original_message)
 
-			else if(C.chatOutput.broken)
+			if(C.chatOutput.broken || !C.chatOutput.loaded)
 				continue // No vchat instance to queue it for, why bother.
-			else if(!C.chatOutput.loaded)
-				continue // If not loaded yet, do nothing and history-sending on load will get it.
 
 			LAZYINITLIST(msg_queue[C])
 			msg_queue[C][++msg_queue[C].len] = messageStruct
@@ -74,9 +72,7 @@ SUBSYSTEM_DEF(chat)
 
 		DIRECT_OUTPUT(C, original_message)
 
-		else if(C.chatOutput.broken)
-			return
-		else if(!C.chatOutput.loaded)
+		if(C.chatOutput.broken || !C.chatOutput.loaded)
 			return // If not loaded yet, do nothing and history-sending on load will get it.
 
 		LAZYINITLIST(msg_queue[C])

--- a/code/controllers/subsystems/chat.dm
+++ b/code/controllers/subsystems/chat.dm
@@ -54,9 +54,13 @@ SUBSYSTEM_DEF(chat)
 
 			if(!C || !C.chatOutput)
 				continue // No client? No care.
+
+			// Originally we didn't send it to oldchat because why? But, turns out that's
+			// really the only way to log-as-a-stream to a file in byond, so, we send it both ways.
+			DIRECT_OUTPUT(C, original_message)
+
 			else if(C.chatOutput.broken)
-				DIRECT_OUTPUT(C, original_message)
-				continue
+				continue // No vchat instance to queue it for, why bother.
 			else if(!C.chatOutput.loaded)
 				continue // If not loaded yet, do nothing and history-sending on load will get it.
 
@@ -67,8 +71,10 @@ SUBSYSTEM_DEF(chat)
 
 		if(!C || !C.chatOutput)
 			return // No client? No care.
+
+		DIRECT_OUTPUT(C, original_message)
+
 		else if(C.chatOutput.broken)
-			DIRECT_OUTPUT(C, original_message)
 			return
 		else if(!C.chatOutput.loaded)
 			return // If not loaded yet, do nothing and history-sending on load will get it.

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -493,8 +493,8 @@
 	set category = "OOC"
 
 	//Timing
-	if(src.chatOutputLoadedAt > (world.time - 10 SECONDS))
-		tgui_alert_async(src, "You can only try to reload VChat every 10 seconds at most.")
+	if(src.chatOutputLoadedAt > (world.time - 5 SECONDS))
+		tgui_alert_async(src, "You cann't reload the chat more than once within 5 seconds.")
 		return
 
 	verbs -= /client/proc/vchat_export_log

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -492,7 +492,7 @@
 	set name = "Reload VChat"
 	set category = "OOC"
 
-	//Timing
+	//RSEdit: Timing reduced to 5s and wording nicer
 	if(src.chatOutputLoadedAt > (world.time - 5 SECONDS))
 		tgui_alert_async(src, "You cann't reload the chat more than once within 5 seconds.")
 		return

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -371,6 +371,10 @@
 	set category = "Preferences"
 	set desc = "Toggles VChat. Reloading VChat and/or reconnecting required to affect changes."
 
+	if(src.chatOutputLoadedAt > (world.time - 5 SECONDS))
+		tgui_alert_async(src, "You can't swap chats more than once within 5 seconds.")
+		return
+
 	var/pref_path = /datum/client_preference/vchat_enable
 	toggle_preference(pref_path)
 	SScharacter_setup.queue_preferences_save(prefs)

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -371,15 +371,17 @@
 	set category = "Preferences"
 	set desc = "Toggles VChat. Reloading VChat and/or reconnecting required to affect changes."
 
+	// RSAdd - Reloading can only happen every 5 seconds
 	if(src.chatOutputLoadedAt > (world.time - 5 SECONDS))
 		tgui_alert_async(src, "You can't swap chats more than once within 5 seconds.")
 		return
+	// RSAdd End
 
 	var/pref_path = /datum/client_preference/vchat_enable
 	toggle_preference(pref_path)
 	SScharacter_setup.queue_preferences_save(prefs)
 
-	reload_vchat()
+	reload_vchat() // RSAdd - Reload the chat for you
 
 /client/verb/toggle_tgui_inputlock()
 	set name = "Toggle TGUI Input Lock"

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -375,9 +375,7 @@
 	toggle_preference(pref_path)
 	SScharacter_setup.queue_preferences_save(prefs)
 
-	to_chat(src, "You have toggled VChat [is_preference_enabled(pref_path) ? "on" : "off"]. \
-		You will have to reload VChat and/or reconnect to the server for these changes to take place. \
-		VChat message persistence is not guaranteed if you change this again before the start of the next round.")
+	reload_vchat()
 
 /client/verb/toggle_tgui_inputlock()
 	set name = "Toggle TGUI Input Lock"


### PR DESCRIPTION
Makes logging your ERP scenes easier by making sure all messages go to oldchat, even when vchat is selected.

So you can just toggle to oldchat, start log, toggle back.

Doing that is annoying, I'll add a nicer way soon.:tm:

The actual changes in this, both untested, like all good changes:
- Toggling vchat reloads it for you
- Always sends messages to normal byond output stream in addition to vchat