### PR TITLE
Mailbag Patch

### DIFF
--- a/code/game/objects/items/mail_rs.dm
+++ b/code/game/objects/items/mail_rs.dm
@@ -160,6 +160,8 @@
 		add_overlay(postmark_image)
 
 /obj/item/mail/attackby(obj/item/W as obj, mob/user as mob)
+	. = ..() // RS Edit, overwritting the proc was causing issues with mail bags.
+
 	// Destination tagging
 	if(istype(W, /obj/item/device/destTagger))
 		var/obj/item/device/destTagger/O = W

--- a/code/game/objects/items/mail_rs.dm
+++ b/code/game/objects/items/mail_rs.dm
@@ -160,7 +160,7 @@
 		add_overlay(postmark_image)
 
 /obj/item/mail/attackby(obj/item/W as obj, mob/user as mob)
-	. = ..() // RS Edit, overwritting the proc was causing issues with mail bags.
+	. = ..() // RS Edit, allows the mail bag to grab the mail.
 
 	// Destination tagging
 	if(istype(W, /obj/item/device/destTagger))


### PR DESCRIPTION
Patches mail not being quick grabable with the mailbag.

Note, this does introduce one bug. Using a clipboard on junk mail will pull the paper out and leave an empty envelope.

I'm not patching the clipboard bug here, as further investigation finds this to be a bug with clipboards themselves, including the ability to pull paper out of fax machines and filing cabinets.

Clipboards will be patched in a separate PR.