### PR TITLE
Adds Awawas to Default Emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -176,7 +176,8 @@ var/list/_human_default_emotes = list(
 	//VOREStation Add End
 	//RS ADD START
 	/decl/emote/audible/yip,
-	/decl/emote/audible/yip/yap
+	/decl/emote/audible/yip/yap,
+	/decl/emote/audible/awawa
 )
 
 	//VOREStation Add Start
@@ -319,7 +320,8 @@ var/list/_simple_mob_default_emotes = list(
 	/decl/emote/audible/purrlong,
 	/decl/emote/audible/dook,
 	/decl/emote/audible/yip,
-	/decl/emote/audible/yip/yap
+	/decl/emote/audible/yip/yap,
+	/decl/emote/audible/awawa // RS Add
 
 	)
 	//VOREStation Add End


### PR DESCRIPTION
Previously the awawas were not usable ingame by any species, this adds the awawa emote to the default emote list for carbon mobs and simple mobs.