### PR TITLE
Staff Blocking Fix

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded_vr.dm
+++ b/code/game/objects/items/weapons/material/twohanded_vr.dm
@@ -71,7 +71,7 @@
 		if(unique_parry_check(user, attacker, damage_source) && prob(parry_chance))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 			playsound(src, 'sound/weapons/punchmiss.ogg', 50, 1)
-		return 1
+			return 1 // RS Edit, this needs to be indented to not block 100% of attacks >.<
 	return 0
 
 /obj/item/weapon/material/twohanded/staff/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)


### PR DESCRIPTION
Fixes Staffs blocking 100% of attacks when they are supposed to only block 20% to 30%

As an aside I think further balancing is needed, as with the proper block rates in place it feels bad to use. But that goes outside of scope for this fix.