### PR TITLE
Tweak vchat winset

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -510,6 +510,10 @@
 	spawn()
 		chatOutput.start()
 
+// RSAdd: For debug purposes
+/client/proc/client_winset(control, params)
+	winset(src, control, params)
+// RSAdd End
 
 //This is for getipintel.net.
 //You're welcome to replace this proc with your own that does your own cool stuff.

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -62,7 +62,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	else if(broken)
 		winset(owner, null, "outputwindow.htmloutput.is-visible=false;outputwindow.oldoutput.is-visible=true;outputwindow.chatloadlabel.is-visible=false")
 	else if(loaded)
-		return //It can do it's own winsets from inside the JS if it's working.
+		//RSEdit: Usually it does its own winset from the JS but it seems to be intermittenly failing in byond 515.1642
+		winset(owner, null, "outputwindow.htmloutput.is-visible=true;outputwindow.oldoutput.is-visible=false;outputwindow.chatloadlabel.is-visible=false")
+
 
 //Shove all the assets at them
 /datum/chatOutput/proc/send_resources()


### PR DESCRIPTION
Untested, also adds a debug proc called client_winset since it might be useful in testing if this doesn't correct the behavior.