### PR TITLE
Makes absorbs escapable and other virgo ports

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -31,6 +31,7 @@
 	var/vore_digest_chance = 25			// Chance to switch to digest mode if resisted
 	var/vore_absorb_chance = 0			// Chance to switch to absorb mode if resisted
 	var/vore_escape_chance = 25			// Chance of resisting out of mob
+	var/vore_escape_chance_absorbed = 20// Chance of absorbed prey finishing an escape. Requires a successful escape roll against the above as well. //RS add - copy from virgo
 
 	var/vore_stomach_name				// The name for the first belly if not "stomach"
 	var/vore_stomach_flavor				// The flavortext for the first belly if not the default
@@ -74,7 +75,10 @@
 	var/new_fullness = 0
 	for(var/obj/belly/B as anything in vore_organs)
 		for(var/mob/living/M in B)
-			new_fullness += M.size_multiplier
+			//RS edit start
+			if(!M.absorbed || B.count_absorbed_prey_for_sprite)
+				new_fullness += M.size_multiplier
+			//RS edit end
 	new_fullness = new_fullness / size_multiplier //Divided by pred's size so a macro mob won't get macro belly from a regular prey.
 	new_fullness = new_fullness * belly_size_multiplier // Some mobs are small even at 100% size. Let's account for that.
 	new_fullness = round(new_fullness, 1) // Because intervals of 0.25 are going to make sprite artists cry.
@@ -239,6 +243,7 @@
 	B.contamination_color = vore_default_contamination_color
 	B.escapable = vore_escape_chance > 0
 	B.escapechance = vore_escape_chance
+	B.escapechance_absorbed = vore_escape_chance_absorbed // RS add
 	B.digestchance = vore_digest_chance
 	B.absorbchance = vore_absorb_chance
 	B.human_prey_swallow_time = swallowTime

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
@@ -81,7 +81,7 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	vore_ignores_undigestable = 0 // they absorb rather than digest, you're going in either way
 	vore_default_mode = DM_HOLD
 	vore_digest_chance = 0			// Chance to switch to digest mode if resisted
-	vore_absorb_chance = 20			// BECOME A PART OF ME.
+	vore_absorb_chance = 100		// Will always start to absorb if the prey fails its generous escape chance // RS edit - copy from virgo
 	vore_pounce_chance = 5 // Small chance to punish people who abuse their nomming behaviour to try and kite them forever with repeated melee attacks.
 	vore_stomach_name = "internal chamber"
 	vore_stomach_flavor	= "You are squeezed into the tight embrace of the alien creature's warm and cozy insides."
@@ -92,7 +92,10 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	var/obj/belly/B = vore_selected
 	B.name = "internal chamber"
 	B.desc = "Having been too slow to disentangle yourself from the gaslamp's tentacles, the alien creature eventually winds enough of them around your body to lift you up off of the ground. Struggle as you might now, it is too late to deny the jellyfish-esque scavenger its lucky catch; inch by inch, the gaslamp tugs you upwards into its equivalent of a stomach, the transition between the cool-to-frigid atmosphere on the outside to its surprising internal heat something you can feel through any outer wear you possess. Minutes pass, soon resulting in the gentle creature's body sporting a rounded, bulging swell, an indistinct shadow shifting and twitching inside it as you squirm about. Be it to escape or simply to get settled, you might want to take care, however. The gaslamp's internal chamber is slick and squishy instead of overly oppressive, yet, each wave of warmth that pulses over you leaves you feeling weaker than the last..."
-
+	//RS edit start - copy from virgo
+	B.escapechance = 40 //easy to squirm out of...
+	B.escapechance_absorbed = 5 //...but EXTREMELY clingy if you fail
+	//RS edit end
 	B.emote_lists[DM_HOLD] = list(
 		"The gaslamp gently bobs up and down as it lazily drifts elsewhere, the movement hardly enough to disturb the shadowy, indistinct figure curled up within it: you.",
 		"The fungal creature’s inner walls tenderly ripple and squeeze about your form for a few moments, squelching softly... until another wave of warmth pulses through the chamber.",

--- a/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
@@ -48,7 +48,7 @@
 	vore_standing_too = 1
 	vore_ignores_undigestable = 0
 	vore_default_mode = DM_DRAIN // They just want to drain you!
-	vore_digest_chance = 25 // But don't you dare try to escape...
+	vore_digest_chance = 0 // RS edit - no digest chance as they use select instead
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 
 /datum/say_list/succubus
@@ -66,8 +66,60 @@
 	B.digest_brute = 2
 	B.digest_burn = 2
 	B.digest_oxy = 1
-	B.digestchance = 25
+	B.selectchance = 25 // RS edit
+	B.digestchance = 0 // RS edit
 	B.absorbchance = 0
 	B.escapechance = 15
-	B.selective_preference = DM_DRAIN
+	B.selective_preference = DM_DIGEST //RS edit
 	B.escape_stun = 5
+	B.transferlocation_absorb = "curves" //RS edit
+
+	//RS edit start
+	var/obj/belly/curves = new /obj/belly(src)
+	curves.immutable = TRUE
+	curves.name = "curves"
+	curves.desc = "Your entire being is cast adrift, no longer tight as it was in the succubus's gut but still inexorably bound, a sensation of warmth surrounding your entire being - it's pleasantly comfortable, relaxing even, as though lulling you, tempting you into simply allowing yourself to drift off. It's difficult to focus on yourself at all, any sense of your own position having abandoned you - instead, you can simply feel an odd, gentle sensation of being occasionally rubbed, stroked, squeezed, your captor eager to enjoy her prize. Even trying to move seems to elicit a satisfied chuckle, almost as though she knows that, at least on some level, some part of you wanted to give yourself to her - and she seemingly has little intention of giving you back."
+	curves.digest_mode = DM_HOLD // like, shes got you already, doesn't need to get you more
+	curves.mode_flags = DM_FLAG_FORCEPSAY
+	curves.escapable = TRUE // good luck
+	curves.escapechance = 40 // high chance of STARTING a successful escape attempt
+	curves.escapechance_absorbed = 5 // m i n e
+	curves.vore_verb = "soak"
+	curves.count_absorbed_prey_for_sprite = FALSE
+
+	curves.absorbed_struggle_messages_inside = list(
+		"You try and push free from %pred's %belly, but can't seem to will yourself to move.",
+		"Your fruitless mental struggles only cause %pred to chuckle lightly.",
+		"You can't make any progress freeing yourself from %pred's %belly.")
+	/* copied from upstream - uncomment these if escape/struggle customisation PR is ported
+	curves.escape_attempt_absorbed_messages_owner = list(
+		"%prey is attempting to free themselves from your %belly!")
+
+	curves.escape_attempt_absorbed_messages_prey = list(
+		"You try to force yourself out of %pred's %belly.",
+		"You strain and push, attempting to reach out of %pred's %belly.",
+		"You work up the will to try and force yourself free of %pred's clutches.")
+
+	curves.escape_absorbed_messages_owner = list(
+		"%prey forces themselves free of your %belly!")
+
+	curves.escape_absorbed_messages_prey = list(
+		"You finally manage to wrest yourself free from %pred's %belly, re-asserting your more usual form.",
+		"You heave and push, eventually spilling out from %pred's %belly, eliciting an amused smile from your former captor.")
+
+	curves.escape_absorbed_messages_outside = list(
+		"%prey suddenly forces themselves free of %pred's %belly!")
+
+	curves.escape_fail_absorbed_messages_owner = list(
+		"%prey's attempt to escape form your %belly has failed!")
+
+	curves.escape_fail_absorbed_messages_prey = list(
+		"Before you manage to reach freedom, you feel yourself getting dragged back into %pred's %belly!",
+		"%pred laughs lightly, simply pressing your wrigging form back into her %belly before you get anywhere.",
+		"%pred gently rubs a finger over her %belly, the gentle pressure breaking your concentration and sending you sinking back into her form.",
+		"Try as you might, you barely make an impression before %pred simply clenches with the most minimal effort, binding you back into her %belly.",
+		"Unfortunately, %pred seems to have absolutely no intention of letting you go, and your futile effort goes nowhere.",
+		"Strain as you might, you can't keep up the effort long enough before you sink back into %pred's %belly.")
+	*/
+
+	//RS edit end


### PR DESCRIPTION
Various ports of stuff I've done on virgo

Adds ability to struggle free when absorbed on a %chance basis - it's necessary to succeed a normal escape roll first and the absorb escape roll is made _after_ the escape timer to see

defaults mobs to 20% chance

adds ability to autotransfer to a new belly on absorb (so for instance you can send them to one with a high starting escape chance but low unabsorb chance)

adds selective mode chance alongside absorb and digest

tweaks gaslamps and succubi to use these

note: these new features are NOT currently editable on the vore panel and the default values are such that nothing will change