### PR TITLE
Color Matrix Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -263,7 +263,7 @@ var/list/gear_datums = list()
 	if(!description)
 		var/obj/O = path
 		description = initial(O.desc)
-	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc)
+	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc, GLOB.gear_tweak_free_matrix_recolor) //RS Edit - Port Chomp 6159
 
 /datum/gear_data
 	var/path


### PR DESCRIPTION
Allows for Color Matric to be used with Loadout Gear!  Draft since this touches character save data and I would like someone to test it before it goes live.  I checked a little to make sure this doesn't impact saves, but would appreciate another check since I want to be sure!

Partial port of: https://github.com/CHOMPStation2/CHOMPStation2/pull/6159