### PR TITLE
Bluespace Bracelet Changes & Deluxe Edition

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -72,7 +72,12 @@
 /datum/gear/utility/bs_bracelet
 	display_name = "bluespace bracelet"
 	path = /obj/item/clothing/gloves/bluespace
-	cost = 5
+	cost = 1
+
+/datum/gear/utility/delux_bs_bracelet
+	display_name = "deluxe bluespace bracelet"
+	path = /obj/item/clothing/gloves/bluespace/deluxe
+	cost = 3
 
 /datum/gear/utility/walkpod
 	display_name = "podzu music player"

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -72,12 +72,14 @@
 /datum/gear/utility/bs_bracelet
 	display_name = "bluespace bracelet"
 	path = /obj/item/clothing/gloves/bluespace
-	cost = 1
+	cost = 1 //RS Edit
 
+//RS Edit Start
 /datum/gear/utility/delux_bs_bracelet
 	display_name = "deluxe bluespace bracelet"
 	path = /obj/item/clothing/gloves/bluespace/deluxe
 	cost = 3
+//RS Edit End
 
 /datum/gear/utility/walkpod
 	display_name = "podzu music player"

--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -187,6 +187,7 @@
 	if(target_size < 0.1)
 		target_size = 0.1
 
+//RS Edit Start
 /obj/item/clothing/gloves/bluespace/deluxe
 	name = "deluxe size standardization bracelet"
 	desc = "A somewhat bulky metal bracelet featuring a crystal, glowing blue. The outer side of the bracelet has an elongated case that one might imagine \
@@ -251,7 +252,7 @@
 			last_activated = world.time
 		else //They chose their current size.
 			return
-
+//RS Edit End
 
 //Same as Nanotrasen Security Uniforms
 /obj/item/clothing/under/ert


### PR DESCRIPTION
Someone mentioned that it was kind of strange that bluespace bracelets cost 5 points in the loadout (33% of your total loadout points) when you can get them from vendors on station.

Additionally, the bluespace bracelet is kind of irrelevant in most cases since you can just get the size changing NIF and adjust it at will as needed.

This PR does two things:
- Reduces the normal Bluespace Bracelet to 1 cost (akin to the rest of the items you can just roll up and grab out of a vendor)
- Creates a 'deluxe' bluespace bracelet

Deluxe Bluespace Bracelet:
- When put on, it functions like a normal bluespace bracelet. It defaults to 100%, so putting it on will make you 100% size.
- Can then be used and the 'normal' size for that bluespace bracelet can be adjusted to be anything from 50% to 150% 
- This changing has a timer like the normal bluespace bracelet. No rapidly changing sizes here!

This 'Deluxe' edition is not as strong as the NIF or bluespace HYPER jumpsuit since it's a loadout item, but still allows for some size shenanigans and allows people to default to a 'normal-ish' size without being set to 100%