### PR TITLE
makes phasing restore escapability to shadekin tummies

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/ability_procs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/ability_procs.dm
@@ -22,7 +22,7 @@
 		mouse_opacity = 1
 		name = real_name
 		for(var/obj/belly/B as anything in vore_organs)
-			B.escapable = initial(B.escapable)
+			B.escapable = TRUE // RS edit
 
 		cut_overlays()
 		alpha = initial(alpha)


### PR DESCRIPTION
Fixes an issue where phasing out would make mob shadekin inescapable (correctly) but phasing back in would set it to the default initial state of a generic belly (ie. false) instead of setting it back to being escapable again

Stops yellow-eyes in particular from becoming inescapable prisons by phasing out and in again (which they do a lot)

Note that a similar issue exists in the "demon" mob phaseshifting and bloodcrawling abilities, along with phaseshifting on carbon shadekin, but those abilities can only be toggled by players who can just turn interactions back on manually and I'd rather not mess with whatever players want to have their bellies set to do.