### PR TITLE
Makes winged flight not custom only.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -209,6 +209,7 @@
 	name = "Winged Flight"
 	desc = "Allows you to fly by using your wings. Don't forget to bring them!"
 	cost = 0
+	custom_only = FALSE // RS ADD
 	has_preferences = list("flight_vore" = list(TRAIT_PREF_TYPE_BOOLEAN, "Flight Vore enabled on spawn", TRAIT_VAREDIT_TARGET_MOB, FALSE))
 
 /datum/trait/positive/winged_flight/apply(var/datum/species/S,var/mob/living/carbon/human/H)


### PR DESCRIPTION
Does what it says on the tin.

If you wanted to do something like, say, a promethean or protean that has wings that can fly, you couldn't do flight vore (or use it for forced slip-vore) because prometheans/proteans couldn't select this trait, only custom species.

I mention this because I was going to make a promethean that can do flight vore and realized I was unable to do such because it never had 'custom_only = FALSE'  applied to it.