### PR TITLE
Enables Prometheans & Proteans to commit flight vore

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -33,7 +33,10 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/prommie_blobform,
 		/mob/living/proc/set_size,
-		/mob/living/carbon/human/proc/promethean_select_opaqueness,
+		/mob/living/carbon/human/proc/promethean_select_opaqueness, //RS EDIT START
+		/mob/living/proc/flying_toggle,
+		/mob/living/proc/flying_vore_toggle,
+		/mob/living/proc/start_wings_hovering //RS EDIT END
 		)
 
 /mob/living/carbon/human/proc/prommie_blobform()

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -109,7 +109,10 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/shapeshifter_select_wings,
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
-		/mob/living/carbon/human/proc/shapeshifter_select_ears
+		/mob/living/carbon/human/proc/shapeshifter_select_ears, //RS EDIT START
+		/mob/living/proc/flying_toggle,
+		/mob/living/proc/flying_vore_toggle,
+		/mob/living/proc/start_wings_hovering, //RS EDIT END
 		)
 
 	var/global/list/abilities = list()


### PR DESCRIPTION
Does what it says on the tin.

If you wanted to do something like, say, a promethean or protean that has wings that can fly, you couldn't do flight vore (or use it for forced slip-vore) because prometheans/proteans couldn't select the trait, only custom species.

I mention this because I was going to make a promethean that can do flight vore and realized I was unable to do such!

This makes it so prommies and proteans have the innate ability to fly (provided they have wings!)