### PR TITLE
Health buffer for bone breaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -422,6 +422,12 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 		burn	-= (picked.burn_dam - burn_was)
 
 		parts -= picked
+
+		//Bone fractures
+		if(health < maxHealth / 2)	//Let's make people a little more tanky! If our overall health is above 50%, don't break bones
+			if(config.bones_can_break && picked.brute_dam > picked.min_broken_damage * config.organ_health_multiplier && !(picked.robotic >= ORGAN_ROBOT))	//Otherwise break it as normal
+				picked.fracture()
+
 	updatehealth()
 	BITSET(hud_updateflag, HEALTH_HUD)
 	if(update)	UpdateDamageIcon()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -821,10 +821,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (open && !clamped && (H && H.should_have_organ(O_HEART)))
 		status |= ORGAN_BLEEDING
 
-	//Bone fractures
+
+	//RS EDIT - MOVED TO human_damage.dm, so that broken bones can only happen when they actually take damage, rather than potentially any life proc
+/*	//Bone fractures
 	if(config.bones_can_break && brute_dam > min_broken_damage * config.organ_health_multiplier && !(robotic >= ORGAN_ROBOT))
 		src.fracture()
-
+*/
 	update_health()
 
 // new damage icon system


### PR DESCRIPTION
Introduces a general health buffer on broken bones in an interest to making lower end combat encounters less punishing for players:

This change makes it so that bones will not break until you have taken 50% of your max HP in damage.
Then afterward it works as normal, and bones will break if they take any damage that ends up over the bone break threshold.
MEANING

The hands and feet are the weakest parts of the body to break. If you deal 15 damage to a hand or foot for a normal human, it will break.

With this proposed change, a normal human would be able to take 50 damage to a hand or foot without having to worry about breaking a bone. If they take 1 more damage to that same hand or foot, then it would break, because it's over the limit of the general buffer, and the bone break limit.

If one's hand takes 50 damage, and then their leg takes 10 damage though, they would still have no broken bones, because the leg took damage second, and 10 damage is not over the leg's bone break limit. However, if the leg takes 10 damage, and then the hand takes 50 damage, the hand would break, because that damage brings it over the 50%, and also the 15 that hands can take.

The hope with this, is to offer a little more room for mistakes in PVE combat before players take damage that they can't reasonably heal. This should hopefully make away missions and combat related events a little more fun for newer players, and anyone dealing with lag such as overseas players. This should make it so that players can soak a few hits in combat encounters without having to worry about dropping their gun or breaking their foot, as long as they have a medic, or medical supplies on hand.

Obviously, this isn't really going to help you if you just let a monster beat on you, since if you end up taking damage over 50%, then all the same broken bones are going to stack up, since the thresholds are still the same.

Of note, this DOESN'T affect bleeding or other kinds of internal damage. While bleeding damage can be very lethal, there is a decent amount of counterplay to bleeding.

There is very little counterplay to broken bones though, so I hoped to find a way to where, broken bones can be more easily prevented by a present and dedicated healer. I wanted this to mitigate the kinds of situations where like, you walk around a corner and a deathclaw slaps you in the foot before you notice it and now you can't walk until someone slaps a splint on you, and you're slowed down for the rest of the mission and stuff like that.

Anyway! Still need to discuss this with staff~