### PR TITLE
[READY] Adds Synthetic Digitigrade Legs

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -27,6 +27,7 @@
 	var/spread_dam = 0
 	var/thick_skin = 0                 // If a needle has a chance to fail to penetrate.
 
+
 	// Appearance vars.
 	var/nonsolid                       // Snowflake warning, reee. Used for slime limbs.
 	var/transparent                    // As above, so below. Used for transparent limbs.
@@ -1147,6 +1148,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			force_icon = R.icon
 			brute_mod *= R.robo_brute_mod
 			burn_mod *= R.robo_burn_mod
+			prosthetic_digi = R.can_be_digitigrade //RS Edit || Ports CHOMPStation PR 5565
 			if(R.lifelike)
 				robotic = ORGAN_LIFELIKE
 				name = "[initial(name)]"
@@ -1426,3 +1428,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/datum/sprite_accessory/marking/mark = markings[M]["datum"]
 			if(mark.hide_body_parts && (organ_tag in mark.hide_body_parts))
 				return 1
+
+//RS Edit || Ports CHOMPStation PR 5565
+/obj/item/organ/external
+	var/prosthetic_digi = FALSE

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1148,7 +1148,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			force_icon = R.icon
 			brute_mod *= R.robo_brute_mod
 			burn_mod *= R.robo_burn_mod
-			prosthetic_digi = R.can_be_digitigrade //RS Edit || Ports CHOMPStation PR 5565
+			digi_prosthetic = R.can_be_digitigrade //RS Edit || Ports CHOMPStation PR 5565
 			if(R.lifelike)
 				robotic = ORGAN_LIFELIKE
 				name = "[initial(name)]"
@@ -1428,7 +1428,3 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/datum/sprite_accessory/marking/mark = markings[M]["datum"]
 			if(mark.hide_body_parts && (organ_tag in mark.hide_body_parts))
 				return 1
-
-//RS Edit || Ports CHOMPStation PR 5565
-/obj/item/organ/external
-	var/prosthetic_digi = FALSE

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -87,12 +87,13 @@ var/global/list/limb_icon_cache = list()
 	// this allows limbs to be set properly when being printed in the bioprinter without an owner
 	// this also allows the preview mannequin to update properly because customisation topic calls don't call a DNA check
 	var/check_digi = istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot)
+	//RS Edit || Ports CHOMPStation PR 5565
 	if(owner)
 		digitigrade = check_digi && owner.digitigrade && (istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot))
 	else if(dna)
 		digitigrade = check_digi && dna.digitigrade && (istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot))
-
-	var/robotic_digi = prosthetic_digi && digitigrade //could make it so the prosthetic digi var is more of a "does this limb have a custom digitigrade sprite for its robospriting" but this is fine for now
+	var/robotic_digi = digi_prosthetic && digitigrade //could make it so the prosthetic digi var is more of a "does this limb have a custom digitigrade sprite for its robospriting" but this is fine for now
+	//RS Edit end
 
 	for(var/M in markings)
 		if (!markings[M]["on"])
@@ -148,7 +149,7 @@ var/global/list/limb_icon_cache = list()
 
 			if(skeletal)
 				mob_icon = new /icon('icons/mob/human_races/r_skeleton.dmi', "[icon_name][gender ? "_[gender]" : ""]")
-			else if (robotic >= ORGAN_ROBOT && !robotic_digi)
+			else if (robotic >= ORGAN_ROBOT && !robotic_digi) //RS Edit || Ports CHOMPStation PR 5565
 				mob_icon = new /icon('icons/mob/human_races/robotic.dmi', "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
@@ -160,10 +161,11 @@ var/global/list/limb_icon_cache = list()
 				mob_icon = new /icon(digitigrade ? species.icodigi : species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
-
+		//RS Edit || Ports CHOMPStation PR 5565
 		if (model && !robotic_digi)
 			icon_cache_key += "_model_[model]"
 			apply_colouration(mob_icon)
+		//RS Edit end
 
 			//Body markings, actually does not include head this time. Done separately above.
 			if((!istype(src,/obj/item/organ/external/head) && !(force_icon && !robotic_digi)) || (model && owner && owner.synth_markings))
@@ -186,7 +188,7 @@ var/global/list/limb_icon_cache = list()
 				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
 
 			// VOREStation edit start
-			if(nail_polish && (force_icon && !robotic_digi))
+			if(nail_polish && (force_icon && !robotic_digi)) //RS Edit || Ports CHOMPStation PR 5565
 				var/icon/I = new(nail_polish.icon, nail_polish.icon_state)
 				I.Blend(nail_polish.color, ICON_MULTIPLY)
 				add_overlay(I)
@@ -194,7 +196,7 @@ var/global/list/limb_icon_cache = list()
 				icon_cache_key += "_[nail_polish.icon]_[nail_polish.icon_state]_[nail_polish.color]"
 			// VOREStation edit end
 
-	if(model)
+	if(model && !robotic_digi) //RS Edit || !robotic_digi is to prevent synthetic digi-leg colorings from being applied twice
 		icon_cache_key += "_model_[model]"
 		should_apply_transparency = TRUE
 		apply_colouration(mob_icon)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -88,9 +88,11 @@ var/global/list/limb_icon_cache = list()
 	// this also allows the preview mannequin to update properly because customisation topic calls don't call a DNA check
 	var/check_digi = istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot)
 	if(owner)
-		digitigrade = check_digi && owner.digitigrade
+		digitigrade = check_digi && owner.digitigrade && (istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot))
 	else if(dna)
-		digitigrade = check_digi && dna.digitigrade
+		digitigrade = check_digi && dna.digitigrade && (istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot))
+
+	var/robotic_digi = prosthetic_digi && digitigrade //could make it so the prosthetic digi var is more of a "does this limb have a custom digitigrade sprite for its robospriting" but this is fine for now
 
 	for(var/M in markings)
 		if (!markings[M]["on"])
@@ -129,7 +131,7 @@ var/global/list/limb_icon_cache = list()
 	else
 		icon_cache_key = "[icon_name]_[force_icon_key]"
 
-	if(force_icon)
+	if(force_icon && !robotic_digi)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")
 	else
 		if(!dna)
@@ -146,7 +148,7 @@ var/global/list/limb_icon_cache = list()
 
 			if(skeletal)
 				mob_icon = new /icon('icons/mob/human_races/r_skeleton.dmi', "[icon_name][gender ? "_[gender]" : ""]")
-			else if (robotic >= ORGAN_ROBOT)
+			else if (robotic >= ORGAN_ROBOT && !robotic_digi)
 				mob_icon = new /icon('icons/mob/human_races/robotic.dmi', "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
@@ -159,8 +161,12 @@ var/global/list/limb_icon_cache = list()
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 
+		if (model && !robotic_digi)
+			icon_cache_key += "_model_[model]"
+			apply_colouration(mob_icon)
+
 			//Body markings, actually does not include head this time. Done separately above.
-			if(!istype(src,/obj/item/organ/external/head))
+			if((!istype(src,/obj/item/organ/external/head) && !(force_icon && !robotic_digi)) || (model && owner && owner.synth_markings))
 				for(var/M in markings)
 					if (!markings[M]["on"])
 						continue
@@ -180,7 +186,7 @@ var/global/list/limb_icon_cache = list()
 				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
 
 			// VOREStation edit start
-			if(nail_polish)
+			if(nail_polish && (force_icon && !robotic_digi))
 				var/icon/I = new(nail_polish.icon, nail_polish.icon_state)
 				I.Blend(nail_polish.color, ICON_MULTIPLY)
 				add_overlay(I)

--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -98,3 +98,39 @@ var/const/cyberbeast_monitor_styles = "blank=cyber_blank;\
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_glacier_taj.dmi'
 	unavailable_to_build = 1
 	parts = list(BP_HEAD)
+
+//RS Edit Start || Ports CHOMPStation PR5565
+/datum/robolimb
+	var/can_be_digitigrade = FALSE //maybe move this over into more of a "does this have a custom digitigrade sprite, and if so, what is its icon file/icon name in the limb's file" when someone can be bothered making them
+
+/datum/robolimb/dsi_tajaran
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_lizard
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_sergal
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_nevrean
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_vulpkanin
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_akula
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_spider
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_zorren
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_fennec
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_teshari/New()
+	. = ..()
+	species_cannot_use -= SPECIES_PROTEAN
+//RS Edit end

--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -99,7 +99,7 @@ var/const/cyberbeast_monitor_styles = "blank=cyber_blank;\
 	unavailable_to_build = 1
 	parts = list(BP_HEAD)
 
-//RS Edit Start || Ports CHOMPStation PR5565
+//RS Edit Start || Ports CHOMPStation PR 5565
 /datum/robolimb
 	var/can_be_digitigrade = FALSE //maybe move this over into more of a "does this have a custom digitigrade sprite, and if so, what is its icon file/icon name in the limb's file" when someone can be bothered making them
 


### PR DESCRIPTION
Adds synthetic digitigrade legs! This pulls from CHOMPStation's implementation of digitigrade synthetic legs, [PR 5565](https://github.com/CHOMPStation2/CHOMPStation2/pull/5565). The only prosthetics that will work with this implementation is the DSI prosthetics, as they are indistinguishable from normal limbs.

Additionally, proteans can also use teshari DSI prosthetics.

~~- TODO: Fix how synthetic digitigrade legs are colored.~~

~~The current problem with this PR is that, it seems like synthetic Digitigrade colors are applied twice, and I'm not quite certain where or how as of yet due to my lack of experience. I'll continue to poke at this, but for now I'm putting this up as a draft PR to see if someone else with more experience has a better idea.~~

PR is ready. Found a logic issue in one of the other functions in the proc. I'm not sure if it's an elegant solution, but it's at least an effective merger between the Modular Chomp files and our forked version of VOREStation's code.