### PR TITLE
Fixes Cryopods and Teleports going Invisible

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -204,7 +204,7 @@
 
 	var/base_icon_state = "cryopod_0" //VOREStation Edit - New Icon
 	var/occupied_icon_state = "cryopod_1" //VOREStation Edit - New Icon
-	var/broken_icon_state = "cryopod_0-p" //RS EDIT
+	//var/broken_icon_state = "cryopod_0-p" //RS EDIT // RS EDIT Version 2, this icon state doesn't exist. Commenting this out until we have a broken icon state to use here.
 	var/on_store_message = "has entered long-term storage."
 	var/on_store_name = "Cryogenic Oversight"
 	var/on_enter_visible_message = "starts climbing into the"
@@ -226,13 +226,15 @@
 	var/announce_leaving = TRUE	//RS ADD
 
 /obj/machinery/cryopod/update_icon()
+	/* RS Edit, commenting this out as there is no broken icon state for cryopods.
 	if((stat & NOPOWER) || (stat & BROKEN))
 		icon_state = broken_icon_state
 	else
-		if(occupant)
-			icon_state = occupied_icon_state
-		else
-			icon_state = base_icon_state
+	*/
+	if(occupant)
+		icon_state = occupied_icon_state
+	else
+		icon_state = base_icon_state
 
 /obj/machinery/cryopod/robot
 	name = "robotic storage unit"


### PR DESCRIPTION
Cryopods and Teleporters were going invisible if entered while power was out. This resolves that issue.