### PR TITLE
Wrist PDA Runtime Fix

### DIFF
--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -66,6 +66,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/notifying_programs = list()
 	var/retro_mode = 0
 
+	var/gunshot_residue //Fixes runtime when firing projectile weapons || Port from VOREStation PR 16424
 /obj/item/device/pda/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))

--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -66,7 +66,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/notifying_programs = list()
 	var/retro_mode = 0
 
-	var/gunshot_residue //Fixes runtime when firing projectile weapons || Port from VOREStation PR 16424
+	var/gunshot_residue //RS Edit: Fixes runtime when firing projectile weapons || Port from VOREStation PR 16424
+
+
 /obj/item/device/pda/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))


### PR DESCRIPTION
Ports [VOREStation PR 16424](https://github.com/VOREStation/VOREStation/pull/16424). Wrist PDAs will generate a runtime when firing projectile weapons due to a missing `gunshot_residue` variable.