### PR TITLE
Prevents Pickup of Self-Occupied Items

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -191,6 +191,11 @@
 	if(stat)
 		return 0
 
+	// prevent picking up items while being in them
+	// RS Edit: Ports VOREStation PR 15780
+	if(istype(A, /obj/item) && A == loc)
+		return 0
+
 	return 1
 
 /*


### PR DESCRIPTION
[Ports VOREStation PR15780](https://github.com/VOREStation/VOREStation/pull/15780), which prevents someone who occupies an item from picking it up (ie. a micro inside of food).