### PR TITLE
Fixes Wrist PDA Runtime

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -90,7 +90,7 @@
 	if(chambered.leaves_residue)
 		var/mob/living/carbon/human/H = loc
 		if(istype(H))
-			if(!H.gloves)
+			if(!istype(H.gloves, /obj/item/clothing)) //RS Edit || Ports VOREStation PR16446
 				H.gunshot_residue = chambered.caliber
 			else
 				var/obj/item/clothing/G = H.gloves


### PR DESCRIPTION
Ports VOREStation [PR16446](https://github.com/VOREStation/VOREStation/pull/16446/), which fixes a runtime generated from wrist-mounted PDAs after firing projectile weapons.