### PR TITLE
Shadekin energy methods

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -492,6 +492,9 @@
 		else
 			B.apply_damage(5, BRUTE, BP_HEAD) //You're getting fangs pushed into your neck. What do you expect????
 
+			var/datum/species/shadekin/SK = species //RS Edit Start. Shadekin energy.
+			if(istype(SK))
+				shadekin_adjust_energy(50) //RS Edit End A base 50. Goes off the equation that can be seen in bellymodes_vr, plus 10 for drinking blood!
 
 		if(!noise && !bleed) //If we're quiet and careful, there should be no blood to serve as evidence
 			B.remove_blood(82) //Removing in one go since we dont want splatter
@@ -513,6 +516,12 @@
 	if(!ishuman(src))
 		return //If you're not a human you don't have permission to do this.
 	var/mob/living/carbon/human/C = src
+	//RS Edit Start
+	var/datum/species/shadekin/SK = species //Important for shadekin stuff!
+	var/is_shadekin = 0
+	if(istype(SK))
+		is_shadekin = 1
+	//RS Edit End
 	var/obj/item/weapon/grab/G = src.get_active_hand()
 	if(!istype(G))
 		to_chat(C, "<span class='warning'>You must be grabbing a creature in your active hand to absorb them.</span>")
@@ -538,15 +547,21 @@
 				to_chat(C, "<span class='notice'>You begin to drain [T]...</span>")
 				to_chat(T, "<span class='danger'>An odd sensation flows through your body as [C] begins to drain you!</span>")
 				C.nutrition = (C.nutrition + (T.nutrition*0.05)) //Drain a small bit at first. 5% of the prey's nutrition.
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.05/10) //RS Edit
 				T.nutrition = T.nutrition*0.95
 			if(2)
 				to_chat(C, "<span class='notice'>You feel stronger with every passing moment of draining [T].</span>")
 				src.visible_message("<span class='danger'>[C] seems to be doing something to [T], resulting in [T]'s body looking weaker with every passing moment!</span>")
 				to_chat(T, "<span class='danger'>You feel weaker with every passing moment as [C] drains you!</span>")
 				C.nutrition = (C.nutrition + (T.nutrition*0.1))
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.1/10) //RS Edit
 				T.nutrition = T.nutrition*0.9
 			if(3 to 99)
 				C.nutrition = (C.nutrition + (T.nutrition*0.1)) //Just keep draining them.
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.1/10) //RS Edit
 				T.nutrition = T.nutrition*0.9
 				T.eye_blurry += 5 //Some eye blurry just to signify to the prey that they are still being drained. This'll stack up over time, leave the prey a bit more "weakened" after the deed is done.
 				if(T.nutrition < 100 && stage < 99 && C.drain_finalized == 1)//Did they drop below 100 nutrition? If so, immediately jump to stage 99 so it can advance to 100.
@@ -555,6 +570,8 @@
 					stage = 3
 			if(100)
 				C.nutrition = (C.nutrition + T.nutrition)
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition/10) //RS Edit
 				T.nutrition = 0 //Completely drained of everything.
 				var/damage_to_be_applied = T.species.total_health //Get their max health.
 				T.apply_damage(damage_to_be_applied, HALLOSS) //Knock em out.
@@ -575,7 +592,12 @@
 	set category = "Abilities"
 	if(!ishuman(src))
 		return //If you're not a human you don't have permission to do this.
-
+	//RS Edit Start
+	var/datum/species/shadekin/SK = species //Important for shadekin stuff!
+	var/is_shadekin = 0
+	if(istype(SK))
+		is_shadekin = 1
+	//RS Edit End
 	var/obj/item/weapon/grab/G = src.get_active_hand()
 	if(!istype(G))
 		to_chat(src, "<span class='warning'>You must be grabbing a creature in your active hand to drain them.</span>")
@@ -604,15 +626,21 @@
 				to_chat(src, "<span class='notice'>You begin to drain [T]...</span>")
 				to_chat(T, "<span class='danger'>An odd sensation flows through your body as [src] begins to drain you!</span>")
 				nutrition = (nutrition + (T.nutrition*0.05)) //Drain a small bit at first. 5% of the prey's nutrition.
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.05/10) //RS Edit
 				T.nutrition = T.nutrition*0.95
 			if(2)
 				to_chat(src, "<span class='notice'>You feel stronger with every passing moment as you drain [T].</span>")
 				visible_message("<span class='danger'>[src] seems to be doing something to [T], resulting in [T]'s body looking weaker with every passing moment!</span>")
 				to_chat(T, "<span class='danger'>You feel weaker with every passing moment as [src] drains you!</span>")
 				nutrition = (nutrition + (T.nutrition*0.1))
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.10/10) //RS Edit
 				T.nutrition = T.nutrition*0.9
 			if(3 to 48) //Should be more than enough to get under 100.
 				nutrition = (nutrition + (T.nutrition*0.1)) //Just keep draining them.
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(T.nutrition*0.10/10) //RS Edit
 				T.nutrition = T.nutrition*0.9
 				T.eye_blurry += 5 //Some eye blurry just to signify to the prey that they are still being drained. This'll stack up over time, leave the prey a bit more "weakened" after the deed is done.
 				if(T.nutrition < 100)//Did they drop below 100 nutrition? If so, do one last check then jump to stage 50 (Lethal!)
@@ -625,6 +653,8 @@
 					to_chat(src, "<span class='danger'>You feel invigorated as you completely drain [T] and begin to move onto draining them lethally before realizing they are too strong for you to do so!</span>")
 					to_chat(T, "<span class='danger'>You feel completely drained as [src] finishes draining you and begins to move onto draining you lethally, but you are too strong for them to do so!</span>")
 					nutrition = (nutrition + T.nutrition)
+					if(is_shadekin) //RS Edit
+						shadekin_adjust_energy(T.nutrition/10) //RS Edit
 					T.nutrition = 0 //Completely drained of everything.
 					var/damage_to_be_applied = T.species.total_health //Get their max health.
 					T.apply_damage(damage_to_be_applied, HALLOSS) //Knock em out.
@@ -644,6 +674,8 @@
 					T.adjustBrainLoss(5) //Will kill them after a short bit!
 				T.eye_blurry += 20 //A lot of eye blurry just to signify to the prey that they are still being drained. This'll stack up over time, leave the prey a bit more "weakened" after the deed is done. More than non-lethal due to their lifeforce being sucked out
 				nutrition = (nutrition + 25) //Assuming brain damage kills at 60, this gives 300 nutrition.
+				if(is_shadekin) //RS Edit
+					shadekin_adjust_energy(2.5) //RS Edit
 			if(99)
 				if(drain_finalized != 1)
 					stage = 51
@@ -684,6 +716,12 @@
 	if(C.absorbing_prey)
 		to_chat(C, "<span class='warning'>You are already feeding someone!</span>")
 		return
+	//RS Edit Start
+	var/datum/species/shadekin/SK = T.species //Important for shadekin stuff!
+	var/is_shadekin = 0
+	if(istype(SK))
+		is_shadekin = 1
+	//RS Edit End
 
 	C.absorbing_prey = 1
 	for(var/stage = 1, stage<=100, stage++) //100 stages.
@@ -692,15 +730,21 @@
 				to_chat(C, "<span class='notice'>You begin to feed [T]...</span>")
 				to_chat(T, "<span class='notice'>An odd sensation flows through your body as [C] begins to feed you!</span>")
 				T.nutrition = (T.nutrition + (C.nutrition*0.05)) //Drain a small bit at first. 5% of the prey's nutrition.
+				if(is_shadekin) //RS Edit
+					T.shadekin_adjust_energy(C.nutrition*0.05/10) //RS Edit
 				C.nutrition = C.nutrition*0.95
 			if(2)
 				to_chat(C, "<span class='notice'>You feel weaker with every passing moment of feeding [T].</span>")
 				src.visible_message("<span class='notice'>[C] seems to be doing something to [T], resulting in [T]'s body looking stronger with every passing moment!</span>")
 				to_chat(T, "<span class='notice'>You feel stronger with every passing moment as [C] feeds you!</span>")
 				T.nutrition = (T.nutrition + (C.nutrition*0.1))
+				if(is_shadekin) //RS Edit
+					T.shadekin_adjust_energy(C.nutrition*0.1/10) //RS Edit
 				C.nutrition = C.nutrition*0.90
 			if(3 to 99)
 				T.nutrition = (T.nutrition + (C.nutrition*0.1)) //Just keep draining them.
+				if(is_shadekin) //RS Edit
+					T.shadekin_adjust_energy(C.nutrition*0.1/10) //RS Edit
 				C.nutrition = C.nutrition*0.9
 				T.eye_blurry += 1 //Eating a slime's body is odd and will make your vision a bit blurry!
 				if(C.nutrition < 100 && stage < 99 && C.drain_finalized == 1)//Did they drop below 100 nutrition? If so, immediately jump to stage 99 so it can advance to 100.
@@ -709,6 +753,8 @@
 					stage = 3
 			if(100)
 				T.nutrition = (T.nutrition + C.nutrition)
+				if(is_shadekin) //RS Edit
+					T.shadekin_adjust_energy(C.nutrition/10) //RS Edit
 				C.nutrition = 0 //Completely drained of everything.
 				C.absorbing_prey = 0
 				to_chat(C, "<span class='danger'>You have completely fed [T] every part of your body!</span>")

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -76,6 +76,20 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		if (istype(B.owner, /mob/living/carbon/human))
 			var/mob/living/carbon/human/howner = B.owner
 			howner.update_fullness()
+
+			//Shadekin energy calculation start!
+			var/datum/species/shadekin/SK = howner.species
+			if(istype(SK))
+				switch(SK.get_shadekin_eyecolor(howner))
+					if(RED_EYES)
+						howner.shadekin_adjust_energy(damage_gain) 	//1dmg to 1 energy, more or less.
+					if(ORANGE_EYES)
+						howner.shadekin_adjust_energy(damage_gain/1.5)
+					if(PURPLE_EYES)
+						howner.shadekin_adjust_energy(damage_gain/1.5)
+					else //Anybody else!
+						howner.shadekin_adjust_energy(damage_gain/2)
+			//Shadekin energy calculation end!
 	consider_healthbar(L, old_health, B.owner)
 	// End RS edit
 	if(isrobot(B.owner))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -357,6 +357,24 @@
 		var/oldnutrition = (L.nutrition * 0.05)
 		L.nutrition = (L.nutrition * 0.95)
 		owner.adjust_nutrition(oldnutrition)
+		if (istype(owner, /mob/living/carbon/human)) //RS Edit Start Is our owner a human?
+			var/mob/living/carbon/human/howner = owner
+			var/datum/species/shadekin/SK = howner.species
+			if(istype(SK))
+				howner.shadekin_adjust_energy(oldnutrition/10)
+			/*
+			||----------------------------------------------------------------------------------------------||
+			||                                    Let's do some M A T H!					||
+			||----------------------------------------------------------------------------------------------||
+			||Let's imagine the prey didn't overeat to an insane degree(cap is 50000 after all)		||
+			||450 gives you the 'fat' warning when it comes to nurtition. Let's use that as our baseline.	||
+			||Let's say that absorbing an ENTIRE person that's full of food should give you 50 energy	||
+			||That 9 nutrition per 1 energy. Not too bad. 							||
+			||Let's assume the average person that just spawned in has 300 nutrition.			||
+			||That's equivalent to 33 energy. Let's just round it to 10 because we like even numbers here.	||
+			||Not doing eye_color specific here because it's already a small amount that it's not an issue.	||
+			||----------------------------------------------------------------------------------------------||
+			*/ //RS Edit End
 
 /obj/belly/proc/updateVRPanels()
 	for(var/mob/living/M in contents)


### PR DESCRIPTION
## Part 1 of the Shadekin Energy PRs 
(Separated because I like to split features and changes when possible.)
This is the 'feature' portion of these two PRs. For the feature portion, see #632 

### Adds new methods for shadekin to gain and gather energy outside of simply existing/hiding in the dark!

## Types:

### Damage based:
#### - Digestion
#### - Bloodfeeder

### Nutrition Based:
#### - Absorption
#### - Drain
#### - Succubus Drain
#### - Feeder


## Digestion:
- Gives varying energy based off of eye color! (The damage calculation is GENERALLY 1 damage to 1 'damage_gain' There's a few oddities like suffocation giving 1 damage_gain for 2 suffocation, but it's not too immensely relevant. Rule of thumb is 1 dmg = 1 damage)

- Extremely filling / size does NOT change the amount gained (I fiddled around with the idea and quickly realized it'd make math REALLY REALLY COMPLICATED)

- Red eyes get 1:1 when it comes to damage. 100 digestion damage to prey = 100 energy.

- Orange and purple eyes get 0.75:1 when it comes to damage. 100 damage = 75 energy.

- Everyone else gets 0.5:1 when it comes to damage. 100 damage = 50 energy.

## Bloodfeeder:
- Gives a base 50 nutrition when using it. 
- As will be mentioned below, this is calculated using the idea of nutrition gained/10 = energy gained.
- It gives  400 nutrition (40 energy) but because you're also talking blood from the person (which harms them for ~10 damage) you're also given the damage into nutrition, equating to a bonus +10 energy for a grand total of 50 energy.

## All Nutrition Based
- Does NOT give varying energy based off eye color. There's so many various ways to get nutrition and it might depend from kin to kin.

- Extremely filling / size does NOT change the amount gained (I fiddled around with the idea and quickly realized it'd make math REALLY REALLY COMPLICATED)

- Formula is nutrition gained divided by 10. (100 nutrition = 10 energy.)

I left a big block of math in the code breaking the nutrition based energy gain down and the logic behind it, which I will repost below.
## Let's do some M A T H

	Let's imagine the prey didn't overeat to an insane degree(cap is 50000 after all)		
	450 gives you the 'fat' warning when it comes to nurtition. Let's use that as our baseline.	
	Let's say that absorbing an ENTIRE person that's full of food should give you 50 energy	
	That 9 nutrition per 1 energy. Not too bad. 							
	Let's assume the average person that just spawned in has 300 nutrition.			
	That's equivalent to 33 energy. Let's just round it to 10 because we like even numbers here.	
	Not doing eye_color specific here because it's already a small amount that it's not an issue.	

## Side Notes
This PR simply handles the vore/vore adjacent side for shadekin. There will be a different PR as well handling their natural regen speeds in light/dark