### PR TITLE
Shadekin Passive Energy Readjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -311,16 +311,20 @@
 	.=..()
 
 	var/eyecolor_type = get_shadekin_eyecolor(H)
+	//RS Edit Start Adjustments for better feeling shadekin.
+
+	//Former(in the dark): BESK: 50 in 200 ||RESK: 50 in 1000 ||PESK: 50 in 100 ||YESK: 50 in 33.3|| GESK: 50 in 50 ||OESK: 50 in 400
+	//Current(in the dark): BESK: 50 in 133 ||RESK: 50 in 200 ||PESK: 50 in 100 ||YESK: 50 in 33.3|| GESK: 50 in 50 ||OESK: 50 in 133
 
 	switch(eyecolor_type)
 		if(BLUE_EYES)
 			total_health = 100
-			energy_light = 0.5
-			energy_dark = 0.5
+			energy_light = 0.75
+			energy_dark = 0.75
 		if(RED_EYES)
 			total_health = 200
-			energy_light = -1
-			energy_dark = 0.1
+			energy_light = -0.5
+			energy_dark = 0.5
 		if(PURPLE_EYES)
 			total_health = 150
 			energy_light = -0.5
@@ -335,8 +339,9 @@
 			energy_dark = 2
 		if(ORANGE_EYES)
 			total_health = 175
-			energy_light = -0.5
-			energy_dark = 0.25
+			energy_light = -0.25
+			energy_dark = 0.75
+	//RS Edit End
 
 	H.maxHealth = total_health
 


### PR DESCRIPTION
## Part 2 of the Shadekin Energy PRs 
(Separated because I like to split features and changes when possible.)
This is the 'change' portion of these two PRs. For the feature portion, see #631 

## CHANGES
##### BESK (Which for all intents and purposes is being considered the 'baseline' energy gain for this PR):
50 in 200 -> 50 in 133.
(This wasn't really too needed, but I wanted to increase their gain so their passive gain isn't the same as RESK)
##### OESK: 
50 in 400 -> 50 in 133 
(BESK still have an edge over them, as OESK will slightly drain in the light. The amount they drain isn't too significant but is more of an incentive to stay out of the light than anything)
##### RESK: 
50 in **1000** -> 50 in 400. 
(This is still a decent amount of time, but with the vore-related shadekin energy gain PR, RESK will have an incentive to drain some energy from their prey via drain mode, absorb mode, or digest mode to get some energy back quicker!)

### Former Charging speeds (in the dark)
##### YESK: 50 ENERGY IN 33 SECONDS
##### GESK: 50 ENERGY IN 50 SECONDS
##### PESK: 50 ENERGY IN 100 SECONDS
##### BESK: 50 ENERGY IN 200 SECONDS
#### OESK: 50 ENERGY IN 400 SECONDS
#### RESK: 50 ENERGY IN 1000 SECONDS

### Modified Charging speeds (in the dark)
##### YESK: 50 ENERGY IN 33 SECONDS
##### GESK: 50 ENERGY IN 50 SECONDS 
##### PESK: 50 ENERGY IN 100 SECONDS
#### BESK: 50 ENERGY IN 133 SECONDS **Changed!
#### OESK: 50 ENERGY IN 133 SECONDS **Changed!
#### RESK: 50 ENERGY IN 200 SECONDS **Changed!

## BACKGROUND MATH
#### Phasing takes anywhere from 50 to 80 depending on conditions.
#### Darkness: 50 || Light: 80 || Modifiers: Add 15 for each 'viewer'
#### This means that phasing out will cost 65-95. (Phasing in is free though!)
#### And that's with just that person, no other viewers!
#### You gain a 'tick' of energy about every 2 seconds (assuming no time dilation)

## Scenario Example
Previously, red eyes used to charge at 0.1 per 2 seconds in dark. (200 seconds per 10 energy) BESK charged at 0.5 per 2 seconds in light/dark

In this scenario, let's say there's two people in maint and a looming shadekin (with former numbers!)

The shadekin phased out in a perfect scenario, meaning they have 50 energy left and they phase back in on one of the people in maint!

Let's just say they have a post at the ready, they phase in (phasenom), post it, and now they now have to wait ~20 seconds to phase back out! (or 320 if they stay in sight of that other person!)

(Phasing out will leave you with weird numbers like '49.1451' (Actual number I got in testing!) even in perfect darkness)

Well, now let's say they want to phase back in and eat the other person their prey was with and 'reunite' them. Phasing back in is simple, no cost!

Now, the shadekin has 0 energy. But they want to phase out to a different place to continue so they don't get stumbled upon!

For most this isn't too big of an issue. BESK need to wait 200 seconds to get their energy back. GESK only require 50 seconds!

For RESK, however, it requires 1000 seconds. 17 minutes to phase back out! (Remember, this is with no lag!)

With this change, RESK only need to wait 400 seconds (This is still 6.66 minutes, BUT they will also have the possibility to drain energy from prey if they want to speed it up some via the other PR!)