### PR TITLE
Adds Mind Binder device from Chompstation

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -438,6 +438,11 @@
 	items -= announce // or the autosay radio.
 
 	for(var/obj/item/W in items)
+		if(islist(W.possessed_voice)) //RS Edit Start
+			for(var/mob/living/V in W.possessed_voice)
+				despawn_occupant(V)
+			W.forceMove(get_turf(src)) //this crashes the MC, so now they get spat back out.
+			continue //RS Edit End
 		//VOREStation Addition Start
 		if(istype(W, /obj/item/device/pda))
 			var/obj/item/device/pda/found_pda = W

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -265,7 +265,7 @@
 			ghost.assumeform(src)
 			ghost.animate_towards(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len >= 1 && !(user.ckey in warned_of_possession)) // RS Edit Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -31,6 +31,12 @@
 
 		var/choice = tgui_alert(usr,"This will swap your mind with the target's mind. This will result in them controlling your body, and you controlling their body. Continue?","Confirmation",list("Continue","Cancel"))
 		if(choice == "Continue" && usr.get_active_hand() == src && usr.Adjacent(M))
+			//RS Edit Start - Admin logging for Body Snatcher usage
+			if(M.ckey && !M.client)
+				log_and_message_admins("attempted to body swap with [key_name(M)] while they were SSD!")
+			else
+				log_and_message_admins("attempted to body swap with [key_name(M)].")
+			//RS Edit End
 
 			usr.visible_message("<span class='warning'>[usr] pushes the device up their forehead and [M]'s head, the device beginning to let out a series of light beeps!</span>","<span class='notice'>You begin swap minds with [M]!</span>")
 			if(do_after(usr,35 SECONDS,M))

--- a/code/game/objects/items/devices/mind_binder.dm
+++ b/code/game/objects/items/devices/mind_binder.dm
@@ -1,0 +1,192 @@
+// Another illegal hack of the sleevemate similar to the Body Snatcher. This one lets you store and bind minds to items.
+/obj/item/mindbinder
+	name = "\improper Mind Binder"
+	desc = "An extremely illegal tool modified from a SleeveMate. It allows the storing and transfer of minds, but can bind them to objects instead of just humanoids."
+	icon = 'icons/obj/device_alt.dmi'
+	icon_state = "sleevemate"
+	item_state = "healthanalyzer"
+	slot_flags = SLOT_BELT
+	w_class = ITEMSIZE_SMALL
+	matter = list(MAT_STEEL = 200)
+	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2, TECH_ILLEGAL = 1)
+	possessed_voice = list()
+	var/self_bind = FALSE
+
+/obj/item/mindbinder/New()
+	..()
+	flags |= NOBLUDGEON //So borgs don't spark.
+
+/obj/item/mindbinder/attack(mob/living/M, mob/living/user)
+	usr.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	return
+
+/obj/item/mindbinder/attack_self(mob/living/user)
+	return
+
+/obj/item/mindbinder/proc/toggle_self_bind()
+	if(possessed_voice.len == 1)
+		to_chat(usr,span_warning("The device beeps a warning that there is already a mind loaded!"))
+		return
+	self_bind = !self_bind
+	if(self_bind)
+		to_chat(usr,span_notice("You prepare the device to use your own mind!"))
+	else
+		to_chat(usr,span_notice("You disable the device from using your mind."))
+	update_icon()
+
+/obj/item/mindbinder/pre_attack(atom/A)
+	if(istype(A, /obj/item/weapon/holder))
+		var/obj/item/weapon/holder/H = A
+		A = H.held_mob
+	if(istype(A, /mob/living))
+		var/mob/living/M = A
+		if(usr == M)
+			toggle_self_bind()
+			return
+		if(possessed_voice.len == 1 || self_bind)
+			if(istype(A, /mob/living/carbon/human)) //This is only set to humans for the time being because I don't want to touch EVERY mob file in the game to white/blacklist them. So for now, you can just slap people back into their bodies!
+				bind_mob(M)
+
+		if(possessed_voice.len == 0 || self_bind)
+			store_mob(M)
+		return
+	if(istype(A, /obj/item))
+		var/obj/item/I = A
+		if(possessed_voice.len == 1 || self_bind)
+			bind_item(I)
+		else
+			store_item(I)
+		return
+	return
+
+// Handle placing a mind into a mob
+/obj/item/mindbinder/proc/bind_mob(mob/living/target)
+	if(possessed_voice.len == 0 && !self_bind)
+		to_chat(usr,span_warning("The device beeps a warning that it doesn't contain a mind to bind!"))
+		return
+
+	if(target.ckey)
+		to_chat(usr,span_warning("The device beeps a warning that the target is already sentient!"))
+		return
+
+	if(self_bind)
+		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You may not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
+		if(!choice || choice == "Cancel") return
+		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
+		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(target))
+			usr.visible_message(span_warning("[usr] presses [src] against [target]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [target]!"))
+			log_and_message_admins("attempted to bind themselves to \an [target] with a Mind Binder.")
+			if(do_after(usr,30 SECONDS,target))
+				if(!target.ckey)
+					usr.mind.transfer_to(target)
+				self_bind = !self_bind
+				update_icon()
+				to_chat(usr,span_notice("Your mind as been bound to [target]."))
+		return
+
+	usr.visible_message(span_warning("[usr] presses [src] against [target]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind someone's mind into [target]!"))
+	log_and_message_admins("attempted to bind [key_name(src.possessed_voice[1])] to \an [target] with a Mind Binder.")
+	var/doTime = 30 SECONDS
+	if(ishuman(target) || issilicon(target) || isanimal(target))
+		doTime = 5 SECONDS
+	if(do_after(usr,doTime,target))
+		if(possessed_voice.len == 1 && !target.ckey)
+			var/mob/living/voice/V = possessed_voice[1]
+			V.mind.transfer_to(target)
+			V.Destroy()
+			possessed_voice = list()
+			to_chat(usr,span_notice("Mind bound to [target]."))
+
+	update_icon()
+
+// Handle placing a mind into an item
+/obj/item/mindbinder/proc/bind_item(obj/item/item)
+	if(possessed_voice.len == 0 && !self_bind)
+		to_chat(usr,span_warning("The device beeps a warning that it doesn't contain a mind to bind!"))
+		return
+
+	if(item.possessed_voice && item.possessed_voice.len)
+		to_chat(usr,span_warning("The device beeps a warning that the target is already sentient!"))
+		return
+
+	if(is_type_in_list(item, item_vore_blacklist))
+		to_chat(usr,span_danger("The item resists your transfer attempt!"))
+		return
+
+	if(self_bind)
+		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You will not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
+		if(!choice || choice == "Cancel") return
+		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
+		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(item))
+			log_and_message_admins("attempted to bind themselves to \an [item] with a Mind Binder.")
+			usr.visible_message(span_warning("[usr] presses [src] against [item]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [item]!"))
+			if(do_after(usr,30 SECONDS,item))
+				item.inhabit_item(usr, null, null, TRUE)
+				self_bind = !self_bind
+				update_icon()
+				to_chat(usr,span_notice("Your mind as been bound to [item]."))
+		return
+
+	log_and_message_admins("attempted to bind [key_name(src.possessed_voice[1])] to \an [item] with a Mind Binder.")
+	usr.visible_message(span_warning("[usr] presses [src] against [item]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind someone's mind into [item]!"))
+	if(do_after(usr,5 SECONDS,item))
+		if(possessed_voice.len == 1)
+			var/mob/living/voice/V = possessed_voice[1]
+			item.inhabit_item(V, null, V.tf_mob_holder, TRUE)
+			V.Destroy()
+			possessed_voice = list()
+			to_chat(usr,span_notice("Mind bound to [item]."))
+
+	update_icon()
+
+// Handle taking a mind out of a mob
+/obj/item/mindbinder/proc/store_mob(mob/living/target)
+	if(possessed_voice.len != 0)
+		to_chat(usr,span_warning("The device beeps a warning that there is already a mind loaded!"))
+		return
+
+	if(!target.mind || (target.mind.name in prevent_respawns))
+		to_chat(usr,span_warning("The device beeps a warning that the target isn't sentient."))
+		return
+
+	var/choice = tgui_alert(usr,"This will download the target's mind into the device. Once their mind is loaded you can then bind it into an item. This will result in the target being stuck until you put them back in their original body. Please make sure OOC prefs align! Continue?","Confirmation",list("Continue","Cancel"))
+	if(choice == "Continue" && usr.get_active_hand() == src && usr.Adjacent(target))
+		if(target.ckey && !target.client)
+			log_and_message_admins("attempted to take [key_name(target)]'s mind with a Mind Binder while they were SSD!")
+		else
+			log_and_message_admins("attempted to take [key_name(target)]'s mind with a Mind Binder.")
+		usr.visible_message(span_warning("[usr] presses [src] against [target]'s head. The device beginning to let out a series of beeps!"),span_notice("You begin to download [target]'s mind!"))
+		if(do_after(usr,30 SECONDS,target))
+			if(possessed_voice.len == 0 && target.mind)
+				inhabit_item(target, target.real_name, null)
+				to_chat(usr,span_notice("Mind successfully stored!"))
+
+	update_icon()
+
+// Handle taking a mind out of an item
+/obj/item/mindbinder/proc/store_item(obj/item/item)
+	if(possessed_voice.len != 0)
+		to_chat(usr,span_warning("The device beeps a warning that there is already a mind loaded!"))
+		return
+
+	if(!(item.possessed_voice && item.possessed_voice.len))
+		return
+
+	var/mob/living/voice/target = item.possessed_voice[1]
+
+	log_and_message_admins("attempted to take [key_name(target)]'s mind out of \an [item] with a Mind Binder.")
+	usr.visible_message(span_warning("[usr] presses [src] against [item]. The device beginning to let out a series of beeps!"),span_notice("You begin to download someone's mind from [item]!"))
+	if(do_after(usr,5 SECONDS,item))
+		if(possessed_voice.len == 0 && item.possessed_voice.Find(target))
+			inhabit_item(target, target.real_name, target.tf_mob_holder)
+			target.Destroy()
+			item.possessed_voice.Remove(target)
+			to_chat(usr,span_notice("Mind successfully stored!"))
+
+	update_icon()
+
+/obj/item/mindbinder/update_icon()
+	if((possessed_voice && possessed_voice.len > 0) || self_bind)
+		icon_state = "[initial(icon_state)]_on"
+	else
+		icon_state = initial(icon_state)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -847,6 +847,10 @@
 
 	if(src && input && !M.stat && in_range(M,src))
 		name = input
+		//RS Edit Start - Rename possessed voices too
+		for(var/mob/living/voice/V in possessed_voice)
+			V.name = input
+		//RS Edit End
 		to_chat(M, "You name the plushie [input], giving it a hug for good luck.")
 		return 1
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -37,6 +37,18 @@
 			m.visible_message("<span class = 'notice'>\The [m] tumbles out of \the [src]!</span>")
 	//VOREStation Add End
 
+
+	//RS Edit Start Start possessed item cleanup
+	if(istype(src, /obj/item))
+		var/obj/item/I = src
+		if(I.possessed_voice && I.possessed_voice.len)
+			for(var/mob/living/voice/V in I.possessed_voice)
+				if(!V.tf_mob_holder)
+					V.ghostize(0)
+					V.stat = DEAD //Helps with autosleeving
+					V.Destroy()
+	//RS Edit End
+
 	return ..()
 
 /obj/Topic(href, href_list, var/datum/tgui_state/state = GLOB.tgui_default_state)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 
 	var/obj/item/organ/internal/brain/B = src
 	if(istype(B) && owner)
-		if(istype(owner, /mob/living/carbon))
+		if(istype(owner, /mob/living/carbon) && owner.ckey) //RSEdit - Make sure owner's mind isn't elsewhere otherwise on brain removal brings them back
 			B.transfer_identity(owner)
 
 	..()

--- a/code/modules/research/designs/misc_vr.dm
+++ b/code/modules/research/designs/misc_vr.dm
@@ -84,3 +84,12 @@
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 4000, MAT_URANIUM = 2000)
 	build_path = /obj/item/device/juke_remote
 	sort_string = "TCVAE"
+
+
+/datum/design/item/general/mindbinder
+	name = "Mind Binder"
+	id = "mindbinder"
+	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ILLEGAL = 2)
+	materials = list(MAT_STEEL = 4000, MAT_GLASS = 4000, MAT_URANIUM = 2000)
+	build_path = /obj/item/mindbinder
+	sort_string = "TBVAB"

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -11,6 +11,8 @@
 				P.id = null
 
 		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
+			V.ghostize(0) //RS Edit - Prevent Reenter Corpse sending observers to the shadow realm
+			V.stat = DEAD //RS Edit - Helps with autosleeving
 			V.Destroy() //Destroy the voice.
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			M.forceMove(item_storage)
@@ -45,6 +47,7 @@
 				P.id = null
 		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
 			V.Destroy() //Destroy the voice.
+			V.stat = DEAD //RS Edit - Helps with autosleeving
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			M.forceMove(item_storage)
 		for(var/obj/item/O in contents)

--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -57,7 +57,7 @@
 		dropInto(user.drop_location())
 		dropped(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len >= 1 && !(user.ckey in warned_of_possession)) //RS Edit Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1231,6 +1231,7 @@
 #include "code\game\objects\items\devices\laserpointer.dm"
 #include "code\game\objects\items\devices\lightreplacer.dm"
 #include "code\game\objects\items\devices\megaphone.dm"
+#include "code\game\objects\items\devices\mind_binder.dm"
 #include "code\game\objects\items\devices\modkit.dm"
 #include "code\game\objects\items\devices\multitool.dm"
 #include "code\game\objects\items\devices\paicard.dm"


### PR DESCRIPTION
Original PR: [Here](https://github.com/CHOMPStation2/CHOMPStation2/pull/7569). Credit to [Fracshun](https://github.com/Fracshun) for making the Mind Binder. Cryo-Crash bugfix credit [here](https://github.com/CHOMPStation2/CHOMPStation2/pull/7673)

### Adds a 'Mind Binder' device, based off the Sleevemate
- Has two toggle modes: Other and Self
- Other allows you to download a mind from someone OR pull a mind out of an already possessed object OR put an already downloaded mind into an object.
- Self allows you to put your mind into a body that has no mind (ex: freshly made sleeve) OR an object.
- Adds it to R&D as an item that requires Uranium and Illegal tech.
- Has a bajillion warnings so you don't accidentally bind yourself into an item or person unknowingly without realizing it could be a VERY BAD IDEA

### Adds various small fixes that were added with the Mind Binder
- Makes possessed objects no longer crash the game if someone goes into the cryo with them
- Makes possessed objects no longer send the person possessing said object go to the void if they're gurgled
- Makes it so when plushies are renamed, the mind is renamed as well.

### Limitations:
#### The Chompstation version has it so mobs can be possessed. This version does not have that.
- Given the fact that going through and touching every file in the game so that mob possession is possible via the Mind Binder would take ages, I am going to leave that feature to either my future self OR whoever wants to tackle that task