### PR TITLE
Adds Give Reagents, and Purge All Reagents as Smite Options

### DIFF
--- a/code/__defines/admin_vr.dm
+++ b/code/__defines/admin_vr.dm
@@ -4,3 +4,6 @@
 #define SMITE_AD_SPAM				"Ad Spam"
 #define SMITE_AUTOSAVE				"10 Second Autosave"
 #define SMITE_AUTOSAVE_WIDE			"10 Second Autosave (AoE)"
+//RS Add
+#define SMITE_GIVECHEM				"Give Reagent"
+#define SMITE_PURGECHEM				"Purge All Reagents"

--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -178,8 +178,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/toggle_event_verb,		//RS ADD
 	/client/proc/change_station_name,	//RS ADD
 	/client/proc/pick_next_random_map,	//RS ADD
-	/client/proc/activate_vore_game		//RS ADD
-
+	/client/proc/activate_vore_game	//RS ADD
 	)
 
 var/list/admin_verbs_spawn = list(


### PR DESCRIPTION
Adds two new smite options, "Give Reagents" and "Purge All Reagents" to hopefully help things go a little bit smoother as opposed to hunting for view variables.

Give reagents allows an admin to apply any reagent to any valid location (Stomach, bloodstream, skin), up to five units. 

Purge all reagents does exactly as it says, it purges the target of all reagents. 

This PR borrows code from [VOREStation PR 16414](https://github.com/VOREStation/VOREStation/pull/16414), though has been slightly adapted for our use case in the smite panel as opposed to the admin effects panel they have there.