### PR TITLE
Adds 'Natural Artist' trait

### DIFF
--- a/code/game/objects/structures/artstuff_rs.dm
+++ b/code/game/objects/structures/artstuff_rs.dm
@@ -13,7 +13,6 @@
 
 /obj/item/paint_brush/organic/Initialize(location)
 	..()
-	START_PROCESSING(SSobj, src)
 	if(ismob(loc))
 		visible_message("[loc.name] pulls out an organic paintbrush of some sort!")
 		creator = loc
@@ -27,25 +26,6 @@
 			qdel(src)
 
 /obj/item/paint_brush/organic/Destroy()
-	STOP_PROCESSING(SSobj, src)
 	creator.linked_brush = null
 	creator = null
 	..()
-
-/obj/item/paint_brush/organic/process()
-	if(!creator || loc != creator || !creator.item_is_in_hands(src))
-		// Tidy up a bit.
-		if(istype(loc,/mob/living/carbon/human))
-			var/mob/living/carbon/human/host = loc
-			if(istype(host))
-				for(var/obj/item/organ/external/organ in host.organs)
-					for(var/obj/item/O in organ.implants)
-						if(O == src)
-							organ.implants -= src
-			host.pinned -= src
-			host.embedded -= src
-			host.drop_from_inventory(src)
-		creator.linked_brush = null
-		spawn(1)
-			if(src)
-				qdel(src)

--- a/code/game/objects/structures/artstuff_rs.dm
+++ b/code/game/objects/structures/artstuff_rs.dm
@@ -1,0 +1,51 @@
+/obj/item/paint_brush/organic
+	name = "organic paintbrush"
+	desc = "A 'paintbrush' made out of some form of organic material. Strange!"
+	description_info = "Click on yourself to change the color!"
+	selected_color = "#000000"
+	force = 0
+	throwforce = 0
+	w_class = ITEMSIZE_HUGE
+	var/mob/living/carbon/human/creator
+
+/obj/item/paint_brush/organic/reset_plane_and_layer()
+	return //Unneeded. The object is deleted.
+
+/obj/item/paint_brush/organic/Initialize(location)
+	..()
+	START_PROCESSING(SSobj, src)
+	if(ismob(loc))
+		visible_message("[loc.name] pulls out an organic paintbrush of some sort!")
+		creator = loc
+
+/obj/item/paint_brush/organic/dropped(mob/user)
+	visible_message("[creator] puts their organic paintbrush back!")
+	if(creator.linked_brush) //Sanity, as it was runtiming during testing.
+		creator.linked_brush = null
+	spawn(1)
+		if(src)
+			qdel(src)
+
+/obj/item/paint_brush/organic/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	creator.linked_brush = null
+	creator = null
+	..()
+
+/obj/item/paint_brush/organic/process()
+	if(!creator || loc != creator || !creator.item_is_in_hands(src))
+		// Tidy up a bit.
+		if(istype(loc,/mob/living/carbon/human))
+			var/mob/living/carbon/human/host = loc
+			if(istype(host))
+				for(var/obj/item/organ/external/organ in host.organs)
+					for(var/obj/item/O in organ.implants)
+						if(O == src)
+							organ.implants -= src
+			host.pinned -= src
+			host.embedded -= src
+			host.drop_from_inventory(src)
+		creator.linked_brush = null
+		spawn(1)
+			if(src)
+				qdel(src)

--- a/code/modules/mob/living/carbon/human/species/species_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/species_rs.dm
@@ -1,6 +1,8 @@
 /datum/species
 	var/vore_belly_default_variant = "H"
 	var/digest_pain = TRUE
+	var/natural_artist = FALSE
+	var/artist_color = "#000000" //Default to black.
 
 /datum/species/unathi
 	vore_belly_default_variant = "L"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1733,3 +1733,49 @@
 		visible_message(ourmsg)
 
 //RS ADD END
+
+//RS ADD
+/mob/living/carbon/human/proc/adjust_art_color()
+	set name = "Adjust Artistic Color"
+	set category = "Abilities"
+	set desc = "Adjust what color you are currently painting with!"
+
+	if(world.time < last_special)
+		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
+		return
+
+	last_special = world.time + 10
+
+	var/set_new_color = input(src,"Select a new color","Artistic Color",species.artist_color) as color
+	if(set_new_color)
+		species.artist_color = set_new_color
+		if(linked_brush) //Do we have a paintbrush already?
+			linked_brush.update_paint(species.artist_color)
+			linked_brush.hud_layerise()
+			linked_brush.color = species.artist_color
+
+/mob/living/carbon/human/proc/extend_retract_brush()
+	set name = "Conjure Natural Brush"
+	set category = "Abilities"
+	set desc = "Pull out or retract your natural paintbrush!"
+
+
+	if(stat || paralysis || weakened || stunned || world.time < last_special)
+		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
+		return
+
+	last_special = world.time + 20 //Anti-spam.
+
+	if(linked_brush)
+		linked_brush.Destroy()
+		visible_message("[src] retracts their organic paintbrush!")
+
+	else
+		var/obj/item/paint_brush/organic/B = new /obj/item/paint_brush/organic(src)
+		linked_brush = B
+		B.color = species.artist_color //Makes the ITEM ITSELF colored to be what is selected.
+		put_in_hands(B)
+		linked_brush.update_paint(species.artist_color)
+		B.hud_layerise()
+
+//RS END

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1087,3 +1087,16 @@
 		var/datum/preferences/P = H.client.prefs
 		P.trait_injection_amount = H.trait_injection_amount
 //RS Edit end
+
+//RS Edit Start
+/datum/trait/neutral/natural_artist
+	name = "Natural Artist"
+	desc = "Your body creates natural pigment or your fluids work like paint! You can paint without a paintbrush."
+	cost = 0
+	var_changes = list("nautral_artist" = TRUE)
+
+/datum/trait/neutral/natural_artist/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/carbon/human/proc/adjust_art_color
+	H.verbs |= /mob/living/carbon/human/proc/extend_retract_brush
+//RS Edit End

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -27,6 +27,7 @@
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
 	var/trash_catching = FALSE 			//RSEdit: Toggle for trash throw vore || Ports trash eater throw vore from CHOMPStation PR#5987
+	var/obj/item/paint_brush/organic/linked_brush 	//RSAddition: Allows for natural painters. This is the paintbrush.
 	//Commented out by maintainer request
 	//var/passtable_reset					//RS Port Chomp PR 7822 || CHOMPEDIT For crawling
 	//var/passtable_crawl_checked = FALSE //RS Port Chomp PR 7822 || CHOMPEDIT For Crawling

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1499,6 +1499,7 @@
 #include "code\game\objects\random\spacesuits.dm"
 #include "code\game\objects\random\unidentified\medicine.dm"
 #include "code\game\objects\structures\artstuff.dm"
+#include "code\game\objects\structures\artstuff_rs.dm"
 #include "code\game\objects\structures\barricades.dm"
 #include "code\game\objects\structures\barsign.dm"
 #include "code\game\objects\structures\bedsheet_bin.dm"


### PR DESCRIPTION
Does what it says on the tin.

![2024-11-13_16-34-26](https://github.com/user-attachments/assets/1da20620-a071-4281-a022-5e1189104bcb)
![2024-11-13_16-34-48](https://github.com/user-attachments/assets/e73da9e9-0af0-435d-b57f-dbdab22b0716)

### Adds a neutral 'Natural Artist' trait for individuals that are made of goo, paint, nanites, or have some other natural, innate ability to paint.

Has two new buttons:
- Adjust Artistic Color (Allows you to select what color you want)
- Conjure Natural Brush (Allows you to conjure/retract your paintbrush)

Did a bunch of kind-of-somewhat-extra stuff after consulting with the God (aka, old code) to make sure you couldn't do cheaty things with it.
- Throwing your appendage (OW) makes it immediately despawn. 
- You can't place your appendage in a backpack. Or anywhere for that matter.


I had originally wanted it so you could just click on the canvas so you could paint (without an in-hand brush) but realized after implementing it that while I had done the BYOND code side complete, I had failed to realize that it also required touching TGUI and revamping how it handles. 
Which, given TGUI code is not my forte, I chose to go a different route (this PR with the 'brush appendage')