### PR TITLE
Digi Prosthetic Legs

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1149,6 +1149,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			force_icon = R.icon
 			brute_mod *= R.robo_brute_mod
 			burn_mod *= R.robo_burn_mod
+			prosthetic_digi = R.can_be_digitigrade //RS EDIT (CS PR #5565)
 			if(R.lifelike)
 				robotic = ORGAN_LIFELIKE
 				name = "[initial(name)]"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1149,7 +1149,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			force_icon = R.icon
 			brute_mod *= R.robo_brute_mod
 			burn_mod *= R.robo_burn_mod
-			prosthetic_digi = R.can_be_digitigrade //RS EDIT (CS PR #5565)
+			digi_prosthetic = R.can_be_digitigrade //RS EDIT (CS PR #5565)
 			if(R.lifelike)
 				robotic = ORGAN_LIFELIKE
 				name = "[initial(name)]"

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -92,44 +92,19 @@ var/global/list/limb_icon_cache = list()
 	else if(dna)
 		digitigrade = check_digi && dna.digitigrade
 
-	for(var/M in markings)
-		if (!markings[M]["on"])
-			continue
-		var/datum/sprite_accessory/marking/mark = markings[M]["datum"]
-		if(mark.organ_override)
-			var/icon/mark_s = new/icon("icon" = mark.icon, "icon_state" = "[mark.icon_state]-[organ_tag]")
-			mob_icon = new /icon("icon" = mark.icon, "icon_state" = "blank")
-			mark_s.Blend(markings[M]["color"], mark.color_blend_mode) // VOREStation edit
-			mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
-			icon_cache_key = "[M][markings[M]["color"]]"
-			for(var/MM in markings)
-				if (!markings[MM]["on"])
-					continue
-				var/datum/sprite_accessory/marking/mark_style = markings[MM]["datum"]
-				if(mark_style.organ_override)
-					continue
-				var/icon/mark_s_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
-				mark_s.Blend(markings[MM]["color"], mark_style.color_blend_mode) // VOREStation edit
-				add_overlay(mark_s_s) //So when it's not on your body, it has icons
-				mob_icon.Blend(mark_s_s, ICON_OVERLAY) //So when it's on your body, it has icons
-				icon_cache_key += "[MM][markings[MM]["color"]]"
-
-			dir = EAST
-			icon = mob_icon
-			return mob_icon
+	var/should_apply_transparency = FALSE
 
 	var/gender = "m"
+	var/skip_forced_icon = skip_robo_icon || (digi_prosthetic && digitigrade) //RS EDIT (CS PR #5565)
 	if(owner && owner.gender == FEMALE)
 		gender = "f"
-
-	var/should_apply_transparency = FALSE
 
 	if(!force_icon_key)
 		icon_cache_key = "[icon_name]_[species ? species.get_bodytype() : SPECIES_HUMAN]" //VOREStation Edit
 	else
 		icon_cache_key = "[icon_name]_[force_icon_key]"
 
-	if(force_icon)
+	if(force_icon && !skip_forced_icon) //RS EDIT (CS PR #5565)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")
 	else
 		if(!dna)
@@ -146,71 +121,57 @@ var/global/list/limb_icon_cache = list()
 
 			if(skeletal)
 				mob_icon = new /icon('icons/mob/human_races/r_skeleton.dmi', "[icon_name][gender ? "_[gender]" : ""]")
-			else if (robotic >= ORGAN_ROBOT)
+			else if (robotic >= ORGAN_ROBOT && !skip_forced_icon)
 				mob_icon = new /icon('icons/mob/human_races/robotic.dmi', "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
-			else if(is_hidden_by_markings())
-				mob_icon = new /icon('icons/mob/human_races/r_blank.dmi', "[icon_name][gender ? "_[gender]" : ""]")
-				should_apply_transparency = TRUE
 			else
-				//Use digi icon if digitigrade, otherwise use regular icon. Ternary operator is based.
-				mob_icon = new /icon(digitigrade ? species.icodigi : species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
-				should_apply_transparency = TRUE
-				apply_colouration(mob_icon)
+				if(is_hidden_by_markings())
+					mob_icon = new /icon('icons/mob/human_races/r_blank.dmi', "[icon_name][gender ? "_[gender]" : ""]")
+					should_apply_transparency = TRUE
+				else
+					//Use digi icon if digitigrade, otherwise use regular icon. Ternary operator is based.
+					mob_icon = new /icon(digitigrade ? species.icodigi : species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
+					should_apply_transparency = TRUE
+					apply_colouration(mob_icon)
 
-			//Body markings, actually does not include head this time. Done separately above.
-			if(!istype(src,/obj/item/organ/external/head))
-				for(var/M in markings)
-					if (!markings[M]["on"])
-						continue
-					var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
-					var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
-					mark_s.Blend(markings[M]["color"], mark_style.color_blend_mode) // VOREStation edit
-					add_overlay(mark_s) //So when it's not on your body, it has icons
-					mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
-					icon_cache_key += "[M][markings[M]["color"]]"
-
-			if(body_hair && islist(h_col) && h_col.len >= 3)
-				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
-				if(!limb_icon_cache[cache_key])
-					var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
-					I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
-					limb_icon_cache[cache_key] = I
-				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
-
-			// VOREStation edit start
-			if(nail_polish)
-				var/icon/I = new(nail_polish.icon, nail_polish.icon_state)
-				I.Blend(nail_polish.color, ICON_MULTIPLY)
-				add_overlay(I)
-				mob_icon.Blend(I, ICON_OVERLAY)
-				icon_cache_key += "_[nail_polish.icon]_[nail_polish.icon_state]_[nail_polish.color]"
-			// VOREStation edit end
-
-	if(model)
+	if (model && !skip_forced_icon) //RS EDIT START (CS PR #5565)
 		icon_cache_key += "_model_[model]"
 		should_apply_transparency = TRUE
-		apply_colouration(mob_icon)
-		if(owner && owner.synth_markings)
-			for(var/M in markings)
-				if (!markings[M]["on"])
-					continue
-				var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
-				var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
-				mark_s.Blend(markings[M]["color"], mark_style.color_blend_mode) // VOREStation edit
-				add_overlay(mark_s) //So when it's not on your body, it has icons
-				mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
-				icon_cache_key += "[M][markings[M]["color"]]"
+		apply_colouration(mob_icon) //RS END START (CS PR #5565)
 
-		if(body_hair && islist(h_col) && h_col.len >= 3)
-			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
-			if(!limb_icon_cache[cache_key])
-				var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
-				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
-				limb_icon_cache[cache_key] = I
-			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
-		// VOREStation edit ends here
+	//Body markings, actually does not include head this time. Done separately above.
+	if((!istype(src,/obj/item/organ/external/head) && !(force_icon && !skip_forced_icon)) || (model && owner && owner.synth_markings)) //RS EDIT (CS PR #5565)
+		for(var/M in markings)
+			if (!markings[M]["on"])
+				continue
+			var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
+			var/isdigitype = mark_style.digitigrade_acceptance //RS EDIT START (CS PR #5565)
+			if(check_digi)
+				if (!(isdigitype & (digitigrade ? MARKING_DIGITIGRADE_ONLY : MARKING_NONDIGI_ONLY))) //checks flags based on which digitigrade type the limb is
+					continue //RS EDIT END (CS PR #5565)
+			var/icon/mark_s = new/icon("icon" = digitigrade ? mark_style.digitigrade_icon : mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]") //RS EDIT (CS PR #5565)
+			mark_s.Blend(markings[M]["color"], mark_style.color_blend_mode) // VOREStation edit
+			add_overlay(mark_s) //So when it's not on your body, it has icons
+			mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+			icon_cache_key += "[M][markings[M]["color"]]"
+
+	if(body_hair && islist(h_col) && h_col.len >= 3)
+		var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
+		if(!limb_icon_cache[cache_key]) //RS COMMENT: Technically, CH PR #5565 has some GLOB stuff  going on here. That is a major refractor for something like this.
+			var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
+			I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
+			limb_icon_cache[cache_key] = I
+		mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
+
+	// VOREStation edit start
+	if(nail_polish && !(force_icon && !skip_forced_icon))
+		var/icon/I = new(nail_polish.icon, nail_polish.icon_state)
+		I.Blend(nail_polish.color, ICON_MULTIPLY)
+		add_overlay(I)
+		mob_icon.Blend(I, ICON_OVERLAY)
+		icon_cache_key += "_[nail_polish.icon]_[nail_polish.icon_state]_[nail_polish.color]"
+	// VOREStation edit end
 
 	if (transparent && !istype(src,/obj/item/organ/external/head) && can_apply_transparency && should_apply_transparency) //VORESTATION EDIT: transparent instead of nonsolid
 		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well

--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -98,3 +98,39 @@ var/const/cyberbeast_monitor_styles = "blank=cyber_blank;\
 	icon = 'icons/mob/human_races/cyberlimbs/zenghu/zenghu_glacier_taj.dmi'
 	unavailable_to_build = 1
 	parts = list(BP_HEAD)
+
+//RS EDIT START (CS PR #5565)
+/datum/robolimb
+	var/can_be_digitigrade = FALSE
+
+/datum/robolimb/dsi_tajaran
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_lizard
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_sergal
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_nevrean
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_vulpkanin
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_akula
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_spider
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_zorren
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_fennec
+	can_be_digitigrade = TRUE
+
+/datum/robolimb/dsi_teshari/New()
+	. = ..()
+	species_cannot_use -= SPECIES_PROTEAN
+//RS EDIT END (CS PR #5565)


### PR DESCRIPTION
Placing this up so people can peek at the code while I sleep. Going to bugtest this pretty thoroughly to make sure it doesn't break anything major, 

- Ports Chomp PR [#5565](https://github.com/CHOMPStation2/CHOMPStation2/pull/5565) (more digitigrade legs and better handling of said legs' icons)
- Side note: 'Allow Synth markings' must be turned on (duh) for markings to show up on prosthetic legs...Obviously. (I did not realize this while testing, which led to a lot of frustration.)

Example of it being used (Left leg is prosthetic digi but right leg is not. Likewise, there is fox-stockings applied to test markings) 
![image](https://github.com/user-attachments/assets/2a39d3d2-ed7e-4340-9787-fe6c35d350cd)

With no stockings:
![image](https://github.com/user-attachments/assets/93f7f724-ff64-49fd-bec4-e83120702364)

With some various markings applied: 
![lWVHYmn](https://github.com/user-attachments/assets/184b8201-db85-4f2e-8e27-df84dc014d3d)

In game 
![59B6R47](https://github.com/user-attachments/assets/e043b0a5-bbc5-476e-be35-9eee8468443e)


Does some modifications to get it to work here.

Does a LOT of moving around things to get it to function properly.


