### PR TITLE
Waddler / Animated Movement (Modified Bubberstation Trait)

### DIFF
--- a/code/game/Rogue Star/waddle.dm
+++ b/code/game/Rogue Star/waddle.dm
@@ -74,11 +74,11 @@
 		return
 	waddle_z = Z_height
 
-	var/min = tgui_input_number(usr, "Put the desired waddle backwards lean. (-4 is default. -12 min, 0 max)", "Set Back Lean", -4, 0, -12)
-	if(min < -12 || min > 0 )
+	var/min = tgui_input_number(usr, "Put the desired waddle backwards lean. (4 is default. 0 min, 12 max)", "Set Back Lean", 4, 12, 0)
+	if(min > 12 || min < 0 )
 		to_chat(usr, "<span class='notice'>Invalid number!</span>")
 		return
-	waddle_min = min
+	waddle_min = -min
 
 	var/max = tgui_input_number(usr, "Put the desired waddle forwards lean. (4 is default. 0 min, 12 max)", "Set Forwards Lean", 4, 12, 0)
 	if(max > 12 || max < 0 )
@@ -91,7 +91,7 @@
 		to_chat(usr, "<span class='notice'>Invalid number!</span>")
 		return
 	waddle_time = time
-	to_chat(usr, "You have set your waddle height to [waddle_z], your back lean to [waddle_min], your forward lean to [waddle_max] and your waddle time to [waddle_time]")
+	to_chat(usr, "You have set your waddle height to [waddle_z], your back lean to [waddle_min], your forward lean to [waddle_max] and your waddle time to [waddle_time]! You will now waddle!")
 	waddler = 1 //Activate it!
 
 /mob/living/proc/waddling_animation(atom/movable/target) //Waddling code done here to cause less potential conflicts with base code.

--- a/code/game/Rogue Star/waddle.dm
+++ b/code/game/Rogue Star/waddle.dm
@@ -7,6 +7,9 @@
 	var/waddle_max = 4
 	var/waddle_time = 2
 
+/mob/living
+	var/waddler = 0 //Off by default.
+/*
 /datum/client_preference/waddling
 	description = "Waddling"
 	key = "WADDLE_TOGGLE"
@@ -25,21 +28,71 @@
 
 	feedback_add_details("admin_verb","TWaddle")
 
+//NOTES: If you want it to be preference based, uncomment this segment and add
+// "if(client && client.is_preference_enabled(/datum/client_preference/waddling))""
+// Inside of living_movement.dm in the /mob/living/Move() proc!
+
+
+*/
+
+/mob/living/silicon/robot/verb/robot_waddle_toggle()
+	set name = "Toggle Waddling"
+	set desc = "Allows you to toggle if you want to walk with a waddle or not!"
+	set category = "Preferences"
+	waddler = !waddler
+	to_chat(src, "You will [ (waddler) ? "now" : "no longer"] waddle.")
+
+/mob/living/silicon/robot/verb/robot_waddle_adjust()
+	set name = "Waddle Adjust"
+	set desc = "Allows you to adjust your waddling."
+	set category = "Preferences"
+	waddle_adjust()
+
 /mob/living/proc/waddle_debug() //Debug tool to debug waddling.
 	set name = "WADDLE DEBUG"
 	set desc = "Allows you to debug waddling!!"
 	set category = "Preferences"
 
-	var/Z = input("Desired Z.", "Set Depth", 0.5) as num
+	var/Z = input("Desired Z.", "Set Z", 0.5) as num
 	waddle_z = Z
-	var/min = input("Desired min.", "Set Depth", -4) as num
+	var/min = input("Desired min.", "Set min", -4) as num
 	waddle_min = min
-	var/max = input("Desired max.", "Set Depth", 4) as num
+	var/max = input("Desired max.", "Set max", 4) as num
 	waddle_max = max
-	var/time = input("Desired time.", "Set Depth", 2) as num
+	var/time = input("Desired time.", "Set time", 2) as num
 	waddle_time = time
 	to_chat(usr, "z = [Z] min = [min] max = [max] time = [time]")
 
+/mob/living/proc/waddle_adjust()
+	set name = "Waddle Adjust"
+	set desc = "Allows you to adjust your waddling."
+	set category = "Preferences"
+
+	var/Z_height = tgui_input_number(usr, "Put the desired waddle height. (0.5 is default. 0 min 4 max)", "Set Height", 0.5, 4, 0)
+	if(Z_height > 4 || Z_height < 0 )
+		to_chat(usr, "<span class='notice'>Invalid height!</span>")
+		return
+	waddle_z = Z_height
+
+	var/min = tgui_input_number(usr, "Put the desired waddle backwards lean. (-4 is default. -12 min, 0 max)", "Set Back Lean", -4, 0, -12)
+	if(min < -12 || min > 0 )
+		to_chat(usr, "<span class='notice'>Invalid number!</span>")
+		return
+	waddle_min = min
+
+	var/max = tgui_input_number(usr, "Put the desired waddle forwards lean. (4 is default. 0 min, 12 max)", "Set Forwards Lean", 4, 12, 0)
+	if(max > 12 || max < 0 )
+		to_chat(usr, "<span class='notice'>Invalid number!</span>")
+		return
+	waddle_max = max
+
+	var/time = tgui_input_number(usr, "Put the desired waddle animation time. (2 is default. 1 min, 2 max)", "Set Time", 2, 2, 1)
+	if(time > 2 || time < 1 )
+		to_chat(usr, "<span class='notice'>Invalid number!</span>")
+		return
+	waddle_time = time
+	to_chat(usr, "You have set your waddle height to [waddle_z], your back lean to [waddle_min], your forward lean to [waddle_max] and your waddle time to [waddle_time]")
+	waddler = 1 //Activate it!
 
 /mob/living/proc/waddling_animation(atom/movable/target) //Waddling code done here to cause less potential conflicts with base code.
 	//NOTE: The defaults are set to their respective values as that's what feels realistic without being comical!
@@ -48,7 +101,7 @@
 	var/min = target.waddle_min //Default -4 How far back the sprite leans!
 	var/max = target.waddle_max //Default 4 How far forward the sprite leans!
 	var/wad_time = waddle_time //Default 2 How long it takes to for the animation to finish! Two is pretty good.
-
+/* //Commented out. Code to enable drugs to affect waddle.
 	if(isliving(target))
 		var/mob/living/waddler = target
 		if(waddler.confused) //Confused? Lean forwards and back further!
@@ -69,6 +122,7 @@
 		for(var/datum/reagent/R in reagents.reagent_list)
 			if(R.id in tachycardics)
 				waddle_z += 3
+*/
 
 	animate(target, pixel_z = target.pixel_z + waddle_z, time = 0)
 	var/prev_transform = target.transform //The person's default state.

--- a/code/game/Rogue Star/waddle.dm
+++ b/code/game/Rogue Star/waddle.dm
@@ -1,0 +1,73 @@
+//This file contains a (heavily) modified version of the Bubberstation waddle.
+
+/atom/movable
+	var/waddling = 0
+	var/waddle_z = 0.5
+	var/waddle_min = -4
+	var/waddle_max = 4
+	var/waddle_time = 2
+
+/datum/client_preference/waddling
+	description = "Waddling"
+	key = "WADDLE_TOGGLE"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+
+/client/verb/toggle_waddle()
+	set name = "Toggle Waddling"
+	set desc = "Allows you to toggle if you want to walk with a waddle or not!"
+	set category = "Preferences"
+	var/pref_path = /datum/client_preference/waddling
+	toggle_preference(pref_path)
+	to_chat(src, "You will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] waddle.")
+
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	feedback_add_details("admin_verb","TWaddle")
+
+/mob/living/proc/waddle_debug() //Debug tool to debug waddling.
+	set name = "WADDLE DEBUG"
+	set desc = "Allows you to debug waddling!!"
+	set category = "Preferences"
+
+	var/Z = input("Desired Z.", "Set Depth", 0.5) as num
+	waddle_z = Z
+	var/min = input("Desired min.", "Set Depth", -4) as num
+	waddle_min = min
+	var/max = input("Desired max.", "Set Depth", 4) as num
+	waddle_max = max
+	var/time = input("Desired time.", "Set Depth", 2) as num
+	waddle_time = time
+	to_chat(usr, "z = [Z] min = [min] max = [max] time = [time]")
+
+
+/mob/living/proc/waddling_animation(atom/movable/target) //Waddling code done here to cause less potential conflicts with base code.
+	//NOTE: The defaults are set to their respective values as that's what feels realistic without being comical!
+	var/prev_pixel_z = target.pixel_z
+	var/waddle_z = target.waddle_z //Default is 0.5. You generally don't want to change this or the person will be bouncing!
+	var/min = target.waddle_min //Default -4 How far back the sprite leans!
+	var/max = target.waddle_max //Default 4 How far forward the sprite leans!
+	var/wad_time = waddle_time //Default 2 How long it takes to for the animation to finish! Two is pretty good.
+
+	if(isliving(target))
+		var/mob/living/waddler = target
+		if(waddler.confused) //Confused? Lean forwards and back further!
+			min -= 4
+			max += 4
+		if(waddler.druggy) //Druggy? Lean forwards and back even more! And movement animations a bit slower for you
+			min -= 8
+			max += 8
+			wad_time += 1
+		if(waddler.drowsyness) //Drowsy? Don't lean back at all, lean forwards much more, and take longer for animations to run!
+			min += 4
+			max += 16
+			wad_time += 3
+		if(waddler.hallucination) //Hallucinating? Shorter time to make you look twitchy!
+			min -= 10
+			max += 10
+			wad_time -= 1
+
+	animate(target, pixel_z = target.pixel_z + waddle_z, time = 0)
+	var/prev_transform = target.transform //The person's default state.
+	animate(pixel_z = prev_pixel_z, transform = turn(target.transform, pick(min, 0, max)), time=wad_time)
+	animate(transform = prev_transform, time = 0)

--- a/code/game/Rogue Star/waddle.dm
+++ b/code/game/Rogue Star/waddle.dm
@@ -66,6 +66,9 @@
 			min -= 10
 			max += 10
 			wad_time -= 1
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.id in tachycardics)
+				waddle_z += 3
 
 	animate(target, pixel_z = target.pixel_z + waddle_z, time = 0)
 	var/prev_transform = target.transform //The person's default state.

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1099,4 +1099,13 @@
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/adjust_art_color
 	H.verbs |= /mob/living/carbon/human/proc/extend_retract_brush
+
+/datum/trait/neutral/waddle
+	name = "Waddle / Animated Movement"
+	desc = "You move in either an animated way or with a quite visible waddle!"
+	cost = 0
+
+/datum/trait/neutral/waddle/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/proc/waddle_adjust
 //RS Edit End

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -263,7 +263,7 @@ default behaviour is:
 		s_active.close(src)
 
 
-	if(client && client.is_preference_enabled(/datum/client_preference/waddling)) //Rs Edit Start - Adds Waddling from BubberStation
+	if(waddler) //Rs Edit Start - Adds Waddling from BubberStation
 		waddling_animation(src) //Rs Edit End - Adds Waddling from BubberStation
 
 /mob/living/proc/dragged(var/mob/living/dragger, var/oldloc)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -262,6 +262,10 @@ default behaviour is:
 	if(s_active && !(s_active in contents) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
 
+
+	if(client && client.is_preference_enabled(/datum/client_preference/waddling)) //Rs Edit Start - Adds Waddling from BubberStation
+		waddling_animation(src) //Rs Edit End - Adds Waddling from BubberStation
+
 /mob/living/proc/dragged(var/mob/living/dragger, var/oldloc)
 	var/area/A = get_area(src)
 	if(lying && !buckled && pull_damage() && A.has_gravity() && (prob(getBruteLoss() * 200 / maxHealth)))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1646,6 +1646,7 @@
 #include "code\game\objects\structures\stool_bed_chair_nest\wheelchair_item.dm"
 #include "code\game\Rogue Star\kiss.dm"
 #include "code\game\Rogue Star\special_persist.dm"
+#include "code\game\Rogue Star\waddle.dm"
 #include "code\game\turfs\simulated.dm"
 #include "code\game\turfs\simulated_vr.dm"
 #include "code\game\turfs\turf.dm"


### PR DESCRIPTION
I searched as far back as I could to find credit for waddling. See: https://github.com/Bubberstation/Bubberstation/commit/14f89968acca662c3886257c93cdf689013ca861 Commit 14f8996 by vuonojenmustaturska on Aug 23, 2018 is as far as I could find.

This is a heavily modified version of the waddler trait.
DEFAULT/RECOMMENDED:
![2024-11-18_06-08-43](https://github.com/user-attachments/assets/e16b07a0-163a-420d-82ef-755d88eac3c5)


MAX Settings:
![2024-11-18_06-07-22](https://github.com/user-attachments/assets/8a2b9b77-84c4-4431-b0cb-2796eeaada50)


Features:
- Adds waddling / Animated Movement! This is a neutral trait. (Borgs get it by default but have a toggle to turn it on/off!)

- See videos above for the 'default' (suggested) waddle and the 'max' waddle

- Makes it simple to proc_call onto someone to allow them to manually adjust their waddle variables! Need someone to JUMP AROUND during an event? Look no further!

- Added (and commented out) a bunch of various ways to further adjust the system. Want it to be a preference? It's able to be commented in! Want to make it so drugs or statuses adjust it? Just have to uncomment one section.