### PR TITLE
Removes Runtime(s)

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -90,7 +90,7 @@
 		Unbuckle(user)
 		return
 
-	if(only_one_driver && ridden.buckled_mobs.len)
+	if(only_one_driver && ridden.buckled_mobs && ridden.buckled_mobs.len) //RS Edit - Fixes a runtime by buckled_mobs not being inheriently a list.
 		var/mob/living/driver = ridden.buckled_mobs[1]
 		if(driver != user)
 			to_chat(user, "<span class='warning'>\The [ridden] can only be controlled by one person at a time, and is currently being controlled by \the [driver].</span>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -452,7 +452,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			stop_following()
 		return
 	var/area/A = get_area(destination)	//RS EDIT START
-	if(A.block_ghosts)
+	if(A && A.block_ghosts) //RS Edit - Was causing runtitmes if called on an non-existant area. (Like the lobby menu!) Fixed.
 		to_chat(src,SPAN_WARNING("Sorry, that area does not allow ghosts."))
 		if(following)
 			stop_following()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -357,9 +357,9 @@
 	switch(mob.incorporeal_move)
 		if(1)
 			var/turf/T = get_step(mob, direct)
-			var/area/A = T.loc	//RS ADD
 			if(!T)
 				return
+			var/area/A = T.loc	//RS ADD
 			if(mob.check_holy(T))
 				to_chat(mob, "<span class='warning'>You cannot get past holy grounds while you are in this plane of existence!</span>")
 				return


### PR DESCRIPTION
Fixes three runtimes.

- If a ghost was in a position that wasn't an area (ex: spawn title screen, 0 0 0) it would check to see if the area had 'block_ghosts' which since the area didn't exist resulted in the check shooting a runtime.

- At some point ridden had their buckled_mobs changed from a list() to a = null. While this is fine, sometimes handle_ride() would be called and ridden.buckle_mobs.len was checked when there was in fact no buckled_mobs. And since 'null' is not a list and can not have a length, it'd runtime.

- In mob_movement.dm, there was:
```c
			var/turf/T = get_step(mob, direct)
			var/area/A = T.loc	//RS ADD
			if(!T)
				return
```
This resulted  in a runtime if T was null, as null can not have a loc. 
The A = T.loc was moved to be below the if(!T) to stop this runtime.