### PR TITLE
Shadekin Light Flicker adjustments

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -501,15 +501,18 @@
 	spawn(0)
 		var/original_color = light_color
 		var/original_on = on
+		var/datum/component/overlay_lighting/OL = GetComponent(/datum/component/overlay_lighting) //BEWARE, ESOTERIC BULLSHIT HERE.
 		for(var/i = 0; i < amount; i++)
 			if(flicker_color && light_color != flicker_color)
 				set_light_color(flicker_color)
+				OL.directional_atom.color = flicker_color
 			on = !on
 			update_brightness()
 			if(!on) // Only play when the light turns off.
 				playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
 			sleep(rand(5, 15))
 		set_light_color(original_color)
+		OL.directional_atom.color = original_color
 		on = original_on
 		update_brightness()
 		flickering = 0

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -33,6 +33,7 @@
 	var/cell_type = /obj/item/weapon/cell/device
 	var/power_usage = 1
 	var/power_use = 1
+	var/flickering = 0 //RS Edit
 
 /obj/item/device/flashlight/Initialize()
 	. = ..()
@@ -491,3 +492,26 @@
 	light_range = 8
 	light_power = 0.1
 	light_color = "#49F37C"
+
+// RS Edit Start
+/obj/item/device/flashlight/proc/flicker(var/amount = rand(10, 20), var/flicker_color, var/forced)
+	if(flickering) return
+	if(power_usage && !forced) return //No energy :(
+	flickering = 1
+	spawn(0)
+		var/original_color = light_color
+		var/original_on = on
+		for(var/i = 0; i < amount; i++)
+			if(flicker_color && light_color != flicker_color)
+				set_light_color(flicker_color)
+			on = !on
+			update_brightness()
+			if(!on) // Only play when the light turns off.
+				playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
+			sleep(rand(5, 15))
+		set_light_color(original_color)
+		on = original_on
+		update_brightness()
+		flickering = 0
+		update_brightness()
+// RS Edit End

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -21,7 +21,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/shadekin, /datum/unarmed_attack/bite/sharp/shadekin)
 	rarity_value = 15	//INTERDIMENSIONAL FLUFFERS
 
-	inherent_verbs = list(/mob/proc/adjust_hive_range)
+	inherent_verbs = list(/mob/proc/adjust_hive_range, /mob/living/carbon/human/proc/adjust_flicker) //RS Edit
 
 	siemens_coefficient = 1
 	darksight = 10

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -177,6 +177,21 @@
 			else
 				if(flicker_time)
 					L.flicker(flicker_time, flicker_color) //RS edit - Variable Flicker!
+
+		//Yes. I could do a 'for(var/atom/movable/AM in range(effectrange, turf))' but that would take so much processing power the old gods would come down and smite me. So instead we will check for specific things.
+
+		for(var/obj/item/device/flashlight/flashlights in range(7, src)) //Find any flashlights near us and make them flicker too!
+			if(istype(flashlights,/obj/item/device/flashlight/glowstick) ||istype(flashlights,/obj/item/device/flashlight/flare)) //No affecting glowsticks or flares...As funny as that is
+				continue
+			flashlights.flicker(flicker_time, flicker_color, TRUE)
+
+		for(var/mob/living/creatures in range(7, src))
+			for(var/obj/item/device/flashlight/held_lights in creatures.contents)
+				if(istype(held_lights,/obj/item/device/flashlight/glowstick) ||istype(held_lights,/obj/item/device/flashlight/flare) ) //No affecting glowsticks or flares...As funny as that is
+					continue
+				held_lights.flicker(flicker_time, flicker_color, TRUE)
+
+				//do the flicker here
 //RS EDIT END
 
 /datum/modifier/shadekin_phase_vision

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -166,17 +166,17 @@
 		ability_flags &= ~AB_PHASE_SHIFTING
 
 		//Affect nearby lights
-		var/destroy_lights = 0
 
 		for(var/obj/machinery/light/L in machines)
 			if(L.z != z || get_dist(src,L) > 10)
 				continue
 
-			if(prob(destroy_lights))
+			if(prob(flicker_break_chance))
 				spawn(rand(5,25))
 					L.broken()
 			else
-				L.flicker(10)
+				if(flicker_time)
+					L.flicker(flicker_time, flicker_color) //RS edit - Variable Flicker!
 //RS EDIT END
 
 /datum/modifier/shadekin_phase_vision
@@ -327,3 +327,31 @@
 	holder.glow_color = initial(holder.glow_color)
 	holder.set_light(0)
 	my_kin = null
+
+/// Light flicker adjusments! Allows you to change three things:
+/// Flicker Length || Flicker Light Break Chance || Flicker colors
+/mob/living/carbon/human/proc/adjust_flicker()
+	set name = "Adjust Light Flicker"
+	set desc = "Allows you to adjust the settings of the light flicker when you phase in!"
+	set category = "Shadekin"
+
+	var/flicker_timer = tgui_input_number(usr, "Adjust how long lights flicker when you phase in! (Min 10 Max 15 in seconds!)", "Set Flicker", 10, 15, 10)
+	if(flicker_timer > 15 || flicker_timer < 10)
+		to_chat(usr,"<span class='warning'>You must choose a number between 10 and 15</span>")
+		return
+	flicker_time = flicker_timer
+	to_chat(usr,"<span class='warning'>Flicker timer set to [flicker_time] seconds!</span>")
+
+	var/set_new_color = input(src,"Select a color you wish the lights to flicker as (Default is #E0EFF0)","Flicker Color",flicker_color) as color
+	if(set_new_color)
+		flicker_color = set_new_color
+	to_chat(usr,"<span class='warning'>Flicker color set to [flicker_color]!</span>")
+
+	var/break_chance = tgui_input_number(usr, "Adjust the % chance for lights to break when you phase in! (Default 0. Min 0. Max 25)", "Set Break Chance", 0, 25, 0)
+	if(break_chance > 25 || break_chance < 0)
+		to_chat(usr,"<span class='warning'>You must choose a number between 0 and 25</span>")
+		return
+	flicker_break_chance = break_chance
+	to_chat(usr,"<span class='warning'>Break chance set to [flicker_break_chance]%</span>")
+
+//RS Edit End

--- a/code/modules/mob/living/living_rs.dm
+++ b/code/modules/mob/living/living_rs.dm
@@ -1,0 +1,5 @@
+/mob/living
+	/// Shadekin Vars
+	var/flicker_time = 10
+	var/flicker_break_chance = 0
+	var/flicker_color = LIGHT_COLOR_INCANDESCENT_TUBE //Ok so, yes. You are looking at this right. It's set to LIGHT_COLOR_INCANDESCENT_TUBE even though there is technically LIGHT_COLOR_INCANDESCENT_BULB as well. They're CLOSE ENOUGH that it's not really too noticible. If I made it so the flicker var detected the light fixture type and that you didn't have the color set to something custom, it'd take so much extra code my head would explode. So, instead, you get this. If you want to fix this, please feel free to as I'd be happy to see that.

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -731,21 +731,26 @@ var/global/list/light_type_cache = list()
 	set_light(brightness_range * bulb_emergency_brightness_mul, max(bulb_emergency_pow_min, bulb_emergency_pow_mul * (cell.charge / cell.maxcharge)), bulb_emergency_colour)
 	return TRUE
 
-/obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
+/obj/machinery/light/proc/flicker(var/amount = rand(10, 20), var/color) //RS Edit: Allows users to flicker lights!
 	if(flickering) return
 	flickering = 1
 	spawn(0)
+		var/original_color = brightness_color //RS Edit - Colorful flickers!
 		if(on && status == LIGHT_OK)
 			for(var/i = 0; i < amount; i++)
 				if(status != LIGHT_OK) break
+				if(color && brightness_color != color) //RS Edit - Colorful flickers!
+					brightness_color = color //RS Edit - Colorful flickers!
 				on = !on
 				update(0)
 				if(!on) // Only play when the light turns off.
 					playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
 				sleep(rand(5, 15))
+			brightness_color = original_color //RS Edit - Colorful flickers!
 			on = (status == LIGHT_OK)
 			update(0)
 		flickering = 0
+		update(0) //RS Edit - Colorful flickers!
 
 // ai attack - turn on/off emergency lighting for a specific fixture
 /obj/machinery/light/attack_ai(mob/user)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2854,6 +2854,7 @@
 #include "code\modules\mob\living\living_defines_vr.dm"
 #include "code\modules\mob\living\living_movement.dm"
 #include "code\modules\mob\living\living_powers.dm"
+#include "code\modules\mob\living\living_rs.dm"
 #include "code\modules\mob\living\living_vr.dm"
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"


### PR DESCRIPTION
## Adds a new toggle to the shadekin ability tab that allows customization of phasing.
### Makes it so flashlights can flicker
- Reworks the shadekin phase-in proc. Makes it so the flicker length, light break %, and the light flicker color is adjusted!

Features: When shadekin use the toggle, it lets them set three things
- How long the light will flicker for in seconds (10 to 15 seconds)
- % chance of the lights breaking upon phasing in (Used to be hardcoded to 0. Now can be set from 0-10%). Can be admin VV'd to allow event shadekin to have higher break chances if desired.
- Allows shadekin to set the color they wish for lights to flicker as when they phase in!
- Makes it so shadekin warping in will make flashlights flicker the selected color as well!

Side things:
- Allows the flicker() proc to allow an input for what color to flicker as.
- Allows the flicker() proc to set the color of the light to what it originally was before it was changed if there is a new color it's flickering to.

Examples of randomly selected colors:
![2024-11-26_23-17-10](https://github.com/user-attachments/assets/8f64dcbb-3ca1-42d9-bf21-49d4150bd2ec)
![2024-11-26_22-02-52](https://github.com/user-attachments/assets/de23c39c-4466-4deb-ac69-fb7c26eff7e1)
![2024-11-26_21-38-55](https://github.com/user-attachments/assets/a94d0042-bf7e-406c-85f8-6178f6ccf2dc)
![2024-11-27_00-19-19](https://github.com/user-attachments/assets/da5af40b-3705-424d-a62a-954cb5d9fd91)

Example of flashlights flickering: (The first example doesn't have the updated 'more colorized' flashlight version. See the second one for up to date example. It's just to show it works on held flashlights.)
![2024-11-27_17-58-44](https://github.com/user-attachments/assets/ffd315ad-5b5f-4f45-b6f0-3fb3dead3832)
![2024-11-27_19-03-39](https://github.com/user-attachments/assets/1f6b464a-3ac4-4b17-80ea-4f2a8919bea8)

