### PR TITLE
Fixes bones

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -423,11 +423,6 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 		parts -= picked
 
-		//Bone fractures
-		if(health < maxHealth / 2)	//Let's make people a little more tanky! If our overall health is above 50%, don't break bones
-			if(config.bones_can_break && picked.brute_dam > picked.min_broken_damage * config.organ_health_multiplier && !(picked.robotic >= ORGAN_ROBOT))	//Otherwise break it as normal
-				picked.fracture()
-
 	updatehealth()
 	BITSET(hud_updateflag, HEALTH_HUD)
 	if(update)	UpdateDamageIcon()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -822,11 +822,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 		status |= ORGAN_BLEEDING
 
 
-	//RS EDIT - MOVED TO human_damage.dm, so that broken bones can only happen when they actually take damage, rather than potentially any life proc
-/*	//Bone fractures
+	//RS EDIT Better Bone Fractures. HP must be <= .5x their total max_health AND the limb must be >min_broken_damage
+	//Bone fractures
 	if(config.bones_can_break && brute_dam > min_broken_damage * config.organ_health_multiplier && !(robotic >= ORGAN_ROBOT))
-		src.fracture()
-*/
+		if(istype(owner,/mob/living/carbon/human))
+			var/mob/living/carbon/human/our_owner = owner
+			if(our_owner.health <= (our_owner.maxHealth*0.5)) //If our owner's health is <= .5 their max health
+				src.fracture()
+
 	update_health()
 
 // new damage icon system


### PR DESCRIPTION
## Fixes the bug introduced by PR #590 where bones would no longer break except under admin intervention scenarios (Forcibly causing dmg via VV tab)

- Simply fixes bug while causing no changes in functionality that PR #590 introduced.