### PR TITLE
Disables the already unselectable select_ambience_freq href and var

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -120,7 +120,7 @@
 		return TOPIC_REFRESH
 	*/
 	else if(href_list["select_ambience_chance"])
-		var/ambience_chance_new = tgui_input_number(user, "Input the chance you'd like to hear ambience played to you (On area change, or by random ambience). 35 means a 35% chance to play ambience. This is a range from 0-100. 0 disables ambience playing entirely. This is also affected by Ambience Frequency.", "Global Preference", pref.ambience_freq, 100, 0)
+		var/ambience_chance_new = tgui_input_number(user, "Input the chance you'd like to hear ambience played to you (On area change, or by random ambience). 35 means a 35% chance to play ambience. This is a range from 0-100. 0 disables ambience playing entirely. This is also affected by Ambience Frequency.", "Global Preference", pref.ambience_chance, 100, 0) //RS Edit: Fixes what it defaults to.
 		if(isnull(ambience_chance_new) || !CanUseTopic(user)) return TOPIC_NOACTION
 		if(ambience_chance_new < 0 || ambience_chance_new > 100) return TOPIC_NOACTION
 		pref.ambience_chance = ambience_chance_new

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -111,14 +111,14 @@
 		if(pref.client)
 			pref.client.fps = fps_new
 		return TOPIC_REFRESH
-
+	/* //RS Edit. See PR #67 for reference. Commenting this out to prevent href hacks.
 	else if(href_list["select_ambience_freq"])
 		var/ambience_new = tgui_input_number(user, "Input how often you wish to hear ambience repeated! (1-60 MINUTES, 0 for disabled)", "Global Preference", pref.ambience_freq, 60, 0)
 		if(isnull(ambience_new) || !CanUseTopic(user)) return TOPIC_NOACTION
 		if(ambience_new < 0 || ambience_new > 60) return TOPIC_NOACTION
 		pref.ambience_freq = ambience_new
 		return TOPIC_REFRESH
-
+	*/
 	else if(href_list["select_ambience_chance"])
 		var/ambience_chance_new = tgui_input_number(user, "Input the chance you'd like to hear ambience played to you (On area change, or by random ambience). 35 means a 35% chance to play ambience. This is a range from 0-100. 0 disables ambience playing entirely. This is also affected by Ambience Frequency.", "Global Preference", pref.ambience_freq, 100, 0)
 		if(isnull(ambience_chance_new) || !CanUseTopic(user)) return TOPIC_NOACTION

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -23,7 +23,7 @@ var/list/preferences_datums = list()
 	var/UI_style_alpha = 255
 	var/tooltipstyle = "Midnight"		//Style for popup tooltips
 	var/client_fps = 40
-	var/ambience_freq = 0				// How often we're playing repeating ambience to a client.
+	//var/ambience_freq = 0				// How often we're playing repeating ambience to a client. //RS Edit. See PR #67. Handled in area/enter()
 	var/ambience_chance = 35			// What's the % chance we'll play ambience (in conjunction with the above frequency)
 
 	var/tgui_fancy = TRUE

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -47,8 +47,8 @@
 	//Check if we're on fire
 	handle_fire()
 
-	if(client && !(client.prefs.ambience_freq == 0))	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them, and do not have repeating ambience disabled.
-		handle_ambience()
+	// if(client && !(client.prefs.ambience_freq == 0)) RS Edit see below	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them, and do not have repeating ambience disabled.
+	//	handle_ambience() //RS Edit: Handled in area enter() code instead.
 
 	//stuff in the stomach
 	//handle_stomach() //VOREStation Code
@@ -94,14 +94,14 @@
 
 /mob/living/proc/handle_stomach()
 	return
-
+/* //RS Edit Start See PR #67 for reference.
 /mob/living/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time as configured per-client, and do not have it disabled, we're going to play ambience again to you, to help break up the silence.
 	if(world.time >= (lastareachange + client.prefs.ambience_freq MINUTES)) // Every 5 minutes (by default, set per-client), we're going to run a 35% chance (by default, also set per-client) to play ambience.
 		var/area/A = get_area(src)
 		if(A)
 			lastareachange = world.time // This will refresh the last area change to prevent this call happening LITERALLY every life tick.
 			A.play_ambience(src, initial = FALSE)
-
+*/ //RS Edit End.
 /mob/living/proc/update_pulling()
 	if(pulling)
 		if(incapacitated())


### PR DESCRIPTION
Does exactly what it says on the tin.

You couldn't access this anyway unless you were specifically mischievous with your browser usage.

- Disables the unselectable ambience_freq href
- Fixes ambience_chance to default to its proper variable instead of ambience_freq
- Comments out the ambience_freq var since it is unused
- Comments out an unused segment in human/life() pertaining to ambience, given it does not function that way anymore.