### PR TITLE
Makes miners spawn with mining voucher. Fixes them. Expands the list.

### DIFF
--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -26,5 +26,5 @@
 	satchel_one  = /obj/item/weapon/storage/backpack/satchel/eng
 	id_type = /obj/item/weapon/card/id/cargo/miner
 	pda_type = /obj/item/device/pda/shaftminer
-	backpack_contents = list(/obj/item/weapon/tool/crowbar = 1, /obj/item/weapon/storage/bag/ore = 1)
+	backpack_contents = list(/obj/item/weapon/tool/crowbar = 1, /obj/item/weapon/storage/bag/ore = 1, /obj/item/mining_voucher = 1) //RS Edit: Adds back mining vouchers.
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -331,25 +331,52 @@
   * * voucher - The voucher card item
   * * redeemer - The person holding it
   */
-/obj/machinery/mineral/equipment_vendor/proc/redeem_voucher(obj/item/mining_voucher/voucher, mob/redeemer)
-	var/selection = tgui_input_list(redeemer, "Pick your equipment", "Mining Voucher Redemption", list("Kinetic Accelerator", "Resonator", "Mining Drone", "Advanced Scanner", "Crusher"))
-	if(!selection || !Adjacent(redeemer) || voucher.loc != redeemer)
-		return
-	//VOREStation Edit Start - Uncommented these
+/obj/machinery/mineral/equipment_vendor/proc/redeem_voucher(obj/item/mining_voucher/voucher, mob/redeemer) //RS Edit Start. I just tore this from the ground up and reworked it.
+	to_chat(redeemer, "You insert your voucher into the machine!")
+	qdel(voucher) //This keeps me from having to place it in a bunch of other places to keep people from cheeesing it.
+	var/selection = tgui_input_list(redeemer, "Pick your equipment.", "Mining Voucher Redemption", list("Kinetic Accelerator + KA Addon", "Resonator + Advanced Ore Scanner", "Survival Pistol & Machete + Survival Addon",))
 	var/drop_location = drop_location()
+	if(!selection || !Adjacent(redeemer))
+		visible_message("[src] shoots the voucher back out.")
+		new /obj/item/mining_voucher(drop_location)
+		return
 	switch(selection)
-		if("Kinetic Accelerator")
+
+		if("Kinetic Accelerator + KA Addon")
 			new /obj/item/weapon/gun/energy/kinetic_accelerator(drop_location)
-		if("Resonator")
+			var/addon_selection = tgui_input_list(redeemer, "Pick your addon", "Mining Voucher Redemption", list("Cooldown", "Range","Holster")) //Just the basics. Nothing too crazy.
+			switch(addon_selection)
+				if("Cooldown")
+					new /obj/item/borg/upgrade/modkit/cooldown(drop_location)
+				if("Range")
+					new /obj/item/borg/upgrade/modkit/range(drop_location)
+				if("Holster")
+					new /obj/item/clothing/accessory/holster/waist/kinetic_accelerator(drop_location)
+
+		if("Resonator + Advanced Ore Scanner")
 			new /obj/item/resonator(drop_location)
-	//VOREStation Edit End
-		// if("Mining Drone")
-		// 	new /obj/item/storage/box/drone_kit(drop_location)
-		// if("Advanced Scanner")
-		// 	new /obj/item/device/t_scanner/adv_mining_scanner(drop_location)
-		// if("Crusher")
-		// 	new /obj/item/twohanded/required/mining_hammer(drop_location)
-	qdel(voucher)
+			new /obj/item/weapon/mining_scanner/advanced(drop_location)
+
+		if("Survival Pistol & Machete + Survival Addon")
+			new /obj/item/weapon/gun/energy/phasegun/pistol(drop_location)
+			new /obj/item/weapon/material/knife/machete(drop_location)
+			var/addon_selection = tgui_input_list(redeemer, "Pick your survival addon", "Mining Voucher Redemption", list("Shelter Capsule", "Glucose", "Panacea", "Trauma", "Medipens")) //Just the basics. Nothing too crazy.
+			switch(addon_selection)
+				if("Shelter Capsule")
+					new /obj/item/device/survivalcapsule(drop_location)
+				if("Glucose")
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/glucose(drop_location)
+				if("Panacea")
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/purity(drop_location)
+				if("Trauma")
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/brute(drop_location)
+				if("Medipens")
+					var/obj/item/weapon/storage/box/medbox = new /obj/item/weapon/storage/box(drop_location)
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/burn(medbox)
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/detox(medbox)
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/oxy(medbox)
+					new /obj/item/weapon/reagent_containers/hypospray/autoinjector/trauma(medbox)
+//RS Edit End
 
 /obj/machinery/mineral/equipment_vendor/proc/new_prize(var/name, var/path, var/cost) // Generic proc for adding new entries. Good for abusing for FUN and PROFIT.
 	if(!cost)


### PR DESCRIPTION
## Makes the miners spawn with mining vouchers again and revamps them.

Features:
- Makes mining vouchers spawn in miner's backpacks again
- Removes the unused rewards from being selectable via the voucher
- Revamps the loadouts of the mining voucher

### Loadouts 
- Kinetic Accelerator + Addon (Cooldown, Range, or Holster)
- Resonator + Advanced Ore Scanner
- Survival Pistol & Machete + Survival Addon (Capsule / Glucose Injector / Trauma Injector / Panacea Injector / General Medipens)
Each loadout has a value of ~1400-1900 depending on selection.


This mainly allows for more variety in staring out when mining. If you want to be 'safe', you can pick the Survival loadout. If you want to hit the ground running and get a bit of a headstart, you can choose the KA or the Resonator.

This mostly makes it so you don't have to grab an ore satchel, run out for 5 minutes and then return to get your 'basic' loadout gear that you can then use to start getting your actual gear (phoron bore, RIG, etc). Just a small QoL.