### PR TITLE
Combines Crisis and Surgery Mediborgs

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -137,7 +137,6 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 
 
 // Used by robots and robot preferences for regular modules.
-//RS Edit || Ports CHOMPStation 6626
 var/list/robot_module_types = list(
 	"Standard", "Engineering", "Surgeon",  "Crisis",
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",

--- a/code/global.dm
+++ b/code/global.dm
@@ -137,8 +137,9 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 
 
 // Used by robots and robot preferences for regular modules.
+//RS Edit || Ports CHOMPStation 6626
 var/list/robot_module_types = list(
-	"Standard", "Engineering", "Surgeon",  "Crisis",
+	"Standard", "Engineering", /*"Surgeon",*/  "Crisis",
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
 	"Research"
 )

--- a/code/global.dm
+++ b/code/global.dm
@@ -139,7 +139,7 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 // Used by robots and robot preferences for regular modules.
 //RS Edit || Ports CHOMPStation 6626
 var/list/robot_module_types = list(
-	"Standard", "Engineering", /*"Surgeon",*/  "Crisis",
+	"Standard", "Engineering", "Surgeon",  "Crisis",
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
 	"Research"
 )

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -94,10 +94,14 @@
 /obj/item/weapon/reagent_containers/borghypo/hound
 	name = "MediHound hypospray"
 	desc = "An advanced chemical synthesizer and injection system utilizing carrier's reserves, designed for heavy-duty medical equipment."
-	charge_cost = 10
-	reagent_ids = list("inaprovaline", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "paracetamol")
+	//RS Edit Start || Ports CHOMPStation PR6626
+	//charge_cost = 10
+	reagent_ids = list("inaprovaline", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol")
+	//RS Edit End
 	var/datum/matter_synth/water = null
 
+// RS Edit || Ports CHOMPStation PR6626
+/*
 /obj/item/weapon/reagent_containers/borghypo/hound/process() //Recharges in smaller steps and uses the water reserves as well.
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
@@ -108,7 +112,7 @@
 					water.use_charge(charge_cost)
 					reagent_volumes[T] = min(reagent_volumes[T] + 1, volume)
 	return 1
-
+*/
 /obj/item/weapon/reagent_containers/borghypo/hound/lost
 	name = "Hound hypospray"
 	desc = "An advanced chemical synthesizer and injection system utilizing carrier's reserves."

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -330,7 +330,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
-	src.modules += new /obj/item/borg/sight/hud/med(src)
 	// RS Edit end
 	var/obj/item/weapon/reagent_containers/spray/PS = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag += PS

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -5,7 +5,7 @@ var/global/list/robot_modules = list(
 	"Research" 		= /obj/item/weapon/robot_module/robot/research,
 	"Miner" 		= /obj/item/weapon/robot_module/robot/miner,
 	"Crisis" 		= /obj/item/weapon/robot_module/robot/medical/crisis,
-	//"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon, // RS Edit || Ports CHOMPStation 6626
+	"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon,
 	"Security" 		= /obj/item/weapon/robot_module/robot/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/robot/security/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/robot/engineering,
@@ -233,15 +233,25 @@ var/global/list/robot_modules = list(
 	pto_type = PTO_MEDICAL
 
 //RS Edit || Ports CHOMPStation 6626
-/*
+
 /obj/item/weapon/robot_module/robot/medical/surgeon
 	name = "surgeon robot module"
 
 /obj/item/weapon/robot_module/robot/medical/surgeon/create_equipment(var/mob/living/silicon/robot/robot)
 	..()
+	//RS Edit start || Ports CHOMPStation 6626 Combining Surgeon and Crisis.
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.modules += new /obj/item/device/sleevemate(src)
+	src.modules += new /obj/item/device/reagent_scanner/adv(src)
+	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/surgeon(src)
+	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
+	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
+	src.modules += new /obj/item/weapon/gripper/medical(src)
+	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
+	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
 	src.modules += new /obj/item/weapon/autopsy_scanner(src)
 	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
@@ -253,11 +263,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
-	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
-	src.modules += new /obj/item/weapon/gripper/medical(src)
-	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
 	src.modules += new /obj/item/weapon/reagent_containers/dropper(src) // Allows surgeon borg to fix necrosis
-	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 
 	var/obj/item/weapon/reagent_containers/spray/PS = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag += PS
@@ -267,9 +273,15 @@ var/global/list/robot_modules = list(
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
 	synths += medicine
 
+	var/obj/item/stack/medical/advanced/clotting/C = new (src) //RS Edit || ports CHOMPStation 6626
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src) //VoreStation edit: we have burn surgeries so they should be able to do them
+	//RS Edit start || ports CHOMPStation 6626
+	C.uses_charge = 1
+	C.charge_costs = list(5000)
+	C.synths = list(medicine)
+	//RS Edit end
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(medicine)
@@ -279,6 +291,7 @@ var/global/list/robot_modules = list(
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
+	src.modules += C
 	src.modules += N
 	src.modules += B
 	src.modules += O
@@ -300,7 +313,7 @@ var/global/list/robot_modules = list(
 		PS.reagents.add_reagent("pacid", 2 * amount)
 
 	..()
-*/
+
 /obj/item/weapon/robot_module/robot/medical/crisis
 	name = "crisis robot module"
 
@@ -330,6 +343,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper(src) // Allows surgeon borg to fix necrosis
 	// RS Edit end
 	var/obj/item/weapon/reagent_containers/spray/PS = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag += PS
@@ -357,6 +371,7 @@ var/global/list/robot_modules = list(
 	S.uses_charge = 1
 	S.charge_costs = list(1000)
 	S.synths = list(medicine)
+	src.modules += C
 	src.modules += O
 	src.modules += B
 	src.modules += S

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -5,7 +5,7 @@ var/global/list/robot_modules = list(
 	"Research" 		= /obj/item/weapon/robot_module/robot/research,
 	"Miner" 		= /obj/item/weapon/robot_module/robot/miner,
 	"Crisis" 		= /obj/item/weapon/robot_module/robot/medical/crisis,
-	"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon,
+	//"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon, // RS Edit || Ports CHOMPStation 6626
 	"Security" 		= /obj/item/weapon/robot_module/robot/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/robot/security/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/robot/engineering,
@@ -232,9 +232,10 @@ var/global/list/robot_modules = list(
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	pto_type = PTO_MEDICAL
 
+//RS Edit || Ports CHOMPStation 6626
+/*
 /obj/item/weapon/robot_module/robot/medical/surgeon
 	name = "surgeon robot module"
-
 
 /obj/item/weapon/robot_module/robot/medical/surgeon/create_equipment(var/mob/living/silicon/robot/robot)
 	..()
@@ -299,7 +300,7 @@ var/global/list/robot_modules = list(
 		PS.reagents.add_reagent("pacid", 2 * amount)
 
 	..()
-
+*/
 /obj/item/weapon/robot_module/robot/medical/crisis
 	name = "crisis robot module"
 
@@ -317,17 +318,37 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gripper/medical(src)
 	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
+	//RS Edit start || Ports CHOMPStation 6626 Combining Surgeon and Crisis.
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
+	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/cautery/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonegel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/FixOVein/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonesetter/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
+	src.modules += new /obj/item/borg/sight/hud/med(src)
+	// RS Edit end
 	var/obj/item/weapon/reagent_containers/spray/PS = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag += PS
 	PS.reagents.add_reagent("pacid", 250)
 	PS.name = "Polyacid spray"
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(30000) //RS Edit || Ports CHOMPStation 6626
 	synths += medicine
 
+	var/obj/item/stack/medical/advanced/clotting/C = new (src) //RS Edit || ports CHOMPStation 6626
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
+	//RS Edit start || ports CHOMPStation 6626
+	C.uses_charge = 1
+	C.charge_costs = list(5000)
+	C.synths = list(medicine)
+	//RS Edit end
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -246,7 +246,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/surgeon(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
-	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	//src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
 	src.modules += new /obj/item/weapon/gripper/medical(src)
@@ -273,28 +273,22 @@ var/global/list/robot_modules = list(
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
 	synths += medicine
 
-	var/obj/item/stack/medical/advanced/clotting/C = new (src) //RS Edit || ports CHOMPStation 6626
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src) //VoreStation edit: we have burn surgeries so they should be able to do them
-	//RS Edit start || ports CHOMPStation 6626
-	C.uses_charge = 1
-	C.charge_costs = list(5000)
-	C.synths = list(medicine)
-	//RS Edit end
-	N.uses_charge = 1
-	N.charge_costs = list(1000)
-	N.synths = list(medicine)
+	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
+
+	S.uses_charge = 1
+	S.charge_costs = list(1000)
+	S.synths = list(medicine)
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
-	src.modules += C
-	src.modules += N
 	src.modules += B
 	src.modules += O
+	src.modules += S
 
 	src.modules += new /obj/item/device/dogborg/sleeper/trauma(src)
 	src.emag += new /obj/item/weapon/dogborg/pounce(src)
@@ -325,7 +319,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/roller_holder(src)
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
-	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	//src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
 	src.modules += new /obj/item/weapon/gripper/medical(src)
@@ -353,15 +347,9 @@ var/global/list/robot_modules = list(
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(30000) //RS Edit || Ports CHOMPStation 6626
 	synths += medicine
 
-	var/obj/item/stack/medical/advanced/clotting/C = new (src) //RS Edit || ports CHOMPStation 6626
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
-	//RS Edit start || ports CHOMPStation 6626
-	C.uses_charge = 1
-	C.charge_costs = list(5000)
-	C.synths = list(medicine)
-	//RS Edit end
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
@@ -371,7 +359,6 @@ var/global/list/robot_modules = list(
 	S.uses_charge = 1
 	S.charge_costs = list(1000)
 	S.synths = list(medicine)
-	src.modules += C
 	src.modules += O
 	src.modules += B
 	src.modules += S

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -14,15 +14,15 @@
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 	var/bypass_protection = FALSE // If true, can inject through things like spacesuits and armor.
 
-	var/list/reagent_ids = list("tricordrazine", "inaprovaline", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	var/list/reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol")
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
 //RS Edit Start || Ports CHOMPStation PR6626
-/*
+
 /obj/item/weapon/reagent_containers/borghypo/surgeon
-	reagent_ids = list("inaprovaline", "dexalin", "tricordrazine", "spaceacillin", "oxycodone")
-*/
+	reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol")
+
 /obj/item/weapon/reagent_containers/borghypo/crisis
 	reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol")
 //RS Edit End

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -18,11 +18,14 @@
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
+//RS Edit Start || Ports CHOMPStation PR6626
+/*
 /obj/item/weapon/reagent_containers/borghypo/surgeon
 	reagent_ids = list("inaprovaline", "dexalin", "tricordrazine", "spaceacillin", "oxycodone")
-
+*/
 /obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list("inaprovaline", "bicaridine", "kelotane", "anti_toxin", "dexalin", "tricordrazine", "spaceacillin", "tramadol")
+	reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol")
+//RS Edit End
 
 /obj/item/weapon/reagent_containers/borghypo/lost
 	reagent_ids = list("tricordrazine", "bicaridine", "dexalin", "anti_toxin", "tramadol", "spaceacillin")


### PR DESCRIPTION
Combines Crisis and Surgery Mediborgs, as well as some minor buffs and QOL changes from [CHOMPStation PR6626](https://github.com/CHOMPStation2/CHOMPStation2/pull/6626).

- Combined Crisis and Surgery mediborg modules so both modules can perform the same functions
- Doubled mediborg's medicine capacity
- Mediborgs now have access to more basic chems
- Mediborgs hypospray no longer requires water to function
- Mediborg industrial dropper was removed in favor of the normal dropper

~~This PR will remain in draft until a borg player can test this code and verify functionality.~~