### PR TITLE
20250115_1913_KH Fixes people flipping back and forth while pinned.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1342,5 +1342,5 @@
 
 /mob/living/set_dir(var/new_dir)
 	. = ..()
-	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
+	if((dir != new_dir) && (size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0))
 		update_transform(TRUE)


### PR DESCRIPTION
This definitely fixes the issue in question but DNM until I can be relatively sure it doesn't break the feature it is patching.