### PR TITLE
adds additional module types to AI shell

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -148,7 +148,9 @@ var/list/emergency_module_types = list(
 )
 // List of modules available to AI shells
 var/list/shell_module_types = list(
-	"Standard", "Service", "Clerical"
+	"Standard", "Engineering", "Surgeon",  "Crisis",
+	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
+	"Research"
 )
 // List of whitelisted modules
 var/list/whitelisted_module_types = list(


### PR DESCRIPTION
This should be a cozy band-aid until the AI rework and Rascal's Pass's sanity check for AI accessibility. Just grants AI the same module list as standard borgs.