### PR TITLE
Fixes bug with medisprays, lets you put a health analyzer and dropper in their kits

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -249,7 +249,7 @@
 	starts_with = list(/obj/item/weapon/revised_hypospray,
 	/obj/item/weapon/paper/medispray_manual,
 	/obj/item/weapon/reagent_containers/glass/beaker/vial = 5)
-	can_hold = list(/obj/item/weapon/revised_hypospray, /obj/item/weapon/reagent_containers/glass/beaker/vial,/obj/item/weapon/paper)
+	can_hold = list(/obj/item/weapon/revised_hypospray, /obj/item/weapon/reagent_containers/glass/beaker/vial,/obj/item/weapon/paper,/obj/item/device/healthanalyzer,/obj/item/weapon/reagent_containers/dropper)
 	//can fit vials, and the mk.I hyospray.
 
 /obj/item/weapon/storage/firstaid/mkIhypokit/cmo
@@ -265,7 +265,7 @@
 	/obj/item/weapon/reagent_containers/glass/bottle/preloaded/keloderma,
 	/obj/item/weapon/reagent_containers/glass/bottle/preloaded/dexalin
 	)
-	can_hold = list(/obj/item/weapon/revised_hypospray, /obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/glass/beaker/vial,/obj/item/weapon/paper)
+	can_hold = list(/obj/item/weapon/revised_hypospray, /obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/glass/beaker/vial,/obj/item/weapon/paper,/obj/item/device/healthanalyzer,/obj/item/weapon/reagent_containers/dropper)
 	item_state_slots = list(slot_r_hand_str = "firstaid-surgery", slot_l_hand_str = "firstaid-surgery")
 	//can fit vials, bottles, and any of the revised hypos.
 /*

--- a/code/modules/reagents/reagent_containers/hypospray_rs.dm
+++ b/code/modules/reagents/reagent_containers/hypospray_rs.dm
@@ -185,9 +185,6 @@
 		if(!affected)
 			to_chat(user, span_warning("The limb is missing!"))
 			return
-		if(affected.status != ORGAN_FLESH)
-			to_chat(user, span_notice("Medicine won't work on a robotic limb!"))
-			return
 
 	//Always log attemped injections for admins
 	var/contained = vial.reagentlist()


### PR DESCRIPTION
Removes robotic limb check from medisprays as it... wasnt actually doing anything and triggering incorrectly on people who had none.

Lets you put a health analyzer and chem dropper in the kits so youre not COMPLETELY fubar if you take it over a belt.