### PR TITLE
Lets you revive disconnected/afk folks

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -304,8 +304,8 @@
 		return bad_vital_organ
 
 	//this needs to be last since if any of the 'other conditions are met their messages take precedence
-	if(!H.client && !H.teleop)
-		return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\""
+	//if(!H.client && !H.teleop) //RS remove, revive afk/ghosted/disconect
+	//	return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\"" //RS remove, revive afk/ghosted/disconect
 
 	return null
 


### PR DESCRIPTION
Commented out / removed the section that causes a failstate if patient disconnected or their ghost isnt in their body currently.

Letting you revive people who have either lagged out or was not connected at that point in time (ragequits do happen)
It sucks for medical players to go through all the effort of fixing up a long dead corpse, only for them to be completely unrevivable, Feels bad man.

Tested, works in both accounts, nice~