### PR TITLE
Shadekin phase Fixes Pt.1

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -8,6 +8,7 @@
 #define INVISIBILITY_LIGHTING             20
 #define INVISIBILITY_LEVEL_ONE            35
 #define INVISIBILITY_LEVEL_TWO            45
+#define INVISIBILITY_SHADEKIN			  55 //RS add Chomp port #7484
 #define INVISIBILITY_OBSERVER             60
 #define INVISIBILITY_EYE		          61
 

--- a/code/game/Rogue Star/_HELPERS/mobs.dm
+++ b/code/game/Rogue Star/_HELPERS/mobs.dm
@@ -1,0 +1,14 @@
+/atom/proc/living_mobs_in_view(var/range = world.view, var/count_held = FALSE)
+	var/list/viewers = oviewers(src, range)
+	if(count_held)
+		viewers = viewers(src,range)
+	var/list/living = list()
+	for(var/mob/living/L in viewers)
+		if(L.is_incorporeal())
+			continue
+		living += L
+		if(count_held)
+			for(var/obj/item/weapon/holder/H in L.contents)
+				if(istype(H.held_mob, /mob/living))
+					living += H.held_mob
+	return living

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -413,6 +413,7 @@
 			if(A == src) continue
 			if(istype(A,/mob/living))
 				if(A:lying) continue
+				if(A.is_incorporeal()) continue // RS Add Chomp port #8267 | CHOMPEdit - CHOMPEdit - For phased entities
 				src.throw_impact(A,speed)
 			if(isobj(A))
 				if(!A.density || A.throwpass)

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -37,6 +37,8 @@
 			continue
 		if(!attack_can_reach(user, SM, 1))
 			continue
+		if(SM.is_incorporeal()) //RS add Chomp port #7484 // CHOMPADD - Don't cleave phased entities.
+			continue
 		if(resolve_attackby(SM, user, attack_modifier = 0.5)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -95,7 +95,7 @@
 
 	if (istype(A,/mob/living))
 		var/mob/living/M = A
-		if(M.lying || M.flying) //VOREStation Edit
+		if(M.lying || M.flying || M.is_incorporeal())  //RS add Chomp port #7484 | CHOMPADD - Don't forget the phased ones.)
 			return ..()
 
 		if(M.dirties_floor())

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -768,6 +768,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 	var/mob/living/target = locate() in view(7,src)
 	if(!target)
 		return 0
+	if(target.is_incorporeal()) //RS add Chomp port #7484 | CHOMPADD - Don't shoot at things that aren't there.
+		return 0
 
 	for(var/datum/stored_item/vending_product/R in shuffle(product_records))
 		throw_item = R.get_product(loc)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -7,7 +7,7 @@
 	if(!istype(M))
 		return
 	if(M.is_incorporeal()) //RS add Chomp port #7484 | CHOMPEdit - Don't buckle phased entities.
-			return
+		return
 
 	if(!has_buckled_mobs() && !M.buckled && !M.anchored && (issmall(M) || prob(round(seed.get_trait(TRAIT_POTENCY)/3))))
 		//wait a tick for the Entered() proc that called HasProximity() to finish (and thus the moving animation),

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -6,6 +6,8 @@
 	var/mob/living/M = AM
 	if(!istype(M))
 		return
+	if(M.is_incorporeal()) //RS add Chomp port #7484 | CHOMPEdit - Don't buckle phased entities.
+			return
 
 	if(!has_buckled_mobs() && !M.buckled && !M.anchored && (issmall(M) || prob(round(seed.get_trait(TRAIT_POTENCY)/3))))
 		//wait a tick for the Entered() proc that called HasProximity() to finish (and thus the moving animation),

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,4 +1,4 @@
-/mob/living/verb/give(var/mob/living/target in living_mobs(1))
+/mob/living/verb/give(var/mob/living/target in living_mobs_in_view(1)) //RS Edit Chomp port #7484
 	set category = "IC"
 	set name = "Give"
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -432,13 +432,15 @@ emp_act
 				I.forceMove(vore_selected)
 				return //RSEdit End
 		if(in_throw_mode && speed <= THROWFORCE_SPEED_DIVISOR)	//empty active hand and we're in throw mode
-			if(canmove && !restrained())
+			if(canmove && !restrained()&& !src.is_incorporeal()) //RS Edit Chomp port #7484 | CHOMPADD - No hands for the phased ones.
 				if(isturf(O.loc))
 					if(can_catch(O))
 						put_in_active_hand(O)
 						visible_message("<span class='warning'>[src] catches [O]!</span>")
 						throw_mode_off()
 						return
+		if(src.is_incorporeal()) //RS Add Chomp port #7484 | CHOMPADD - Don't hit what's not there.
+			return
 
 		var/dtype = O.damtype
 		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -263,7 +263,7 @@
 	to_chat(src, "<span class='notice'>You take a moment to listen in to your environment...</span>")
 	for(var/mob/living/L in range(client.view, src))
 		var/turf/T = get_turf(L)
-		if(!T || L == src || L.stat == DEAD || is_below_sound_pressure(T))
+		if(!T || L == src || L.stat == DEAD || is_below_sound_pressure(T) || L.is_incorporeal()) //RS Edit Chomp port #7484 | CHOMPAdd - No bluespace ears.
 			continue
 		heard_something = TRUE
 		var/feedback = list()

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -108,12 +108,17 @@
 			B.escapable = FALSE
 
 		var/obj/effect/temp_visual/shadekin/phase_out/phaseanim = new /obj/effect/temp_visual/shadekin/phase_out(src.loc)
+		//RS Add | Chomp port #8267
+		phaseanim.pixel_y = (src.size_multiplier - 1) * 16 // Pixel shift for the animation placement
+		phaseanim.adjust_scale(src.size_multiplier, src.size_multiplier)
+		//Rs Add end
 		phaseanim.dir = dir
 		alpha = 0
 		add_modifier(/datum/modifier/shadekin_phase_vision)
 		sleep(5)
-		invisibility = INVISIBILITY_LEVEL_TWO
-		see_invisible = INVISIBILITY_LEVEL_TWO
+		invisibility = INVISIBILITY_SHADEKIN
+		see_invisible = INVISIBILITY_SHADEKIN
+		see_invisible_default = INVISIBILITY_SHADEKIN //RS Add Chomp port #7484 | CHOMPEdit - Allow seeing phased entities while phased.
 		//cut_overlays()
 		update_icon()
 		alpha = 127
@@ -146,6 +151,10 @@
 
 		//Cosmetics mostly
 		var/obj/effect/temp_visual/shadekin/phase_in/phaseanim = new /obj/effect/temp_visual/shadekin/phase_in(src.loc)
+		//RS Add | Chomp port #8267
+		phaseanim.pixel_y = (src.size_multiplier - 1) * 16 // Pixel shift for the animation placement
+		phaseanim.adjust_scale(src.size_multiplier, src.size_multiplier)
+		//Rs Add end
 		phaseanim.dir = dir
 		alpha = 0
 		custom_emote(1,"phases in!")

--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/robot/verb/robot_nom(var/mob/living/T in living_mobs(1))
+/mob/living/silicon/robot/verb/robot_nom(var/mob/living/T in living_mobs_in_view(1)) //RS Edit Chomp port #7484 | CHOMPAdd - No eating phased ones
 	set name = "Robot Nom"
 	set category = "IC"
 	set desc = "Allows you to eat someone."

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -101,6 +101,8 @@
 	if(src == M) //Don't eat YOURSELF dork
 		//ai_log("vr/won't eat [M] because it's me!", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
+	if(M.is_incorporeal()) //RS Edit Chomp port #7484 | CHOMPADD - No eating the phased ones
+		return 0
 	if(vore_ignores_undigestable && !M.digestable) //Don't eat people with nogurgle prefs
 		//ai_log("vr/wont eat [M] because I am picky", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
@@ -144,6 +146,8 @@
 
 /mob/living/simple_mob/proc/CanPounceTarget(var/mob/living/M) //returns either FALSE or a %chance of success
 	if(!M.canmove || issilicon(M) || world.time < vore_pounce_cooldown) //eliminate situations where pouncing CANNOT happen
+		return FALSE
+	if(M.is_incorporeal()) //RS Add Chomp port #7484 | CHOMPADD - No pouncing on the shades
 		return FALSE
 	if(!prob(vore_pounce_chance) || !will_eat(M)) //mob doesn't want to pounce
 		return FALSE

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
@@ -52,6 +52,8 @@
 	if(ismob(AM))
 		if(isliving(AM))
 			var/mob/living/A = AM
+			if(A.is_incorporeal()) //RS Add Chomp port #7484 | CHOMPADD - Bad kin, no squishing the roach
+				return
 			if(A.mob_size > MOB_SMALL)
 				if(prob(squish_chance))
 					A.visible_message("<span class='notice'>[A] squashed [src].</span>", "<span class='notice'>You squashed [src].</span>")

--- a/code/modules/projectiles/targeting/targeting_gun.dm
+++ b/code/modules/projectiles/targeting/targeting_gun.dm
@@ -17,7 +17,7 @@
 	user.face_atom(A)
 	if(ismob(A) && user.aiming)
 		user.aiming.aim_at(A, src)
-		if(!isliving(A))
+		if(!isliving(A) || A.is_incorporeal()) //RS Add Chomp port #7484 | CHOMPEdit - Phase out can't be targetted when phased
 			return 0
 		return 1
 	return 0

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -386,7 +386,7 @@
 //
 // Clearly super important. Obviously.
 //
-/mob/living/proc/lick(mob/living/tasted in living_mobs(1,TRUE))	//RS EDIT
+/mob/living/proc/lick(mob/living/tasted in living_mobs_in_view(1, TRUE)) //RS Add Chomp port #7484 | no cross dimensional licking
 	set name = "Lick"
 	set category = "IC"
 	set desc = "Lick someone nearby!"
@@ -427,7 +427,7 @@
 
 
 //This is just the above proc but switched about.
-/mob/living/proc/smell(mob/living/smelled in living_mobs(1, TRUE))	//RS EDIT
+/mob/living/proc/smell(mob/living/smelled  in living_mobs_in_view(1, TRUE)) //RS Add Chomp port #7484 | no cross dimensional Sniffing <- I kinda like the sniffing tho it funny
 	set name = "Smell"
 	set category = "IC"
 	set desc = "Smell someone nearby!"

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -236,6 +236,8 @@
 				var/datum/sprite_accessory/tail/taur/tail = H.tail_style
 				src_message = tail.msg_owner_help_run
 				tmob_message = tail.msg_prey_help_run
+			if(tmob.is_incorporeal())	//RS Add Chomp port #7484 | CHOMPEdit - Nothing to step over. (dont step over phased kin)
+				return TRUE
 
 		//Smaller person stepping under larger person
 		else if(get_effective_size(TRUE) < tmob.get_effective_size(TRUE) && ishuman(tmob))
@@ -246,6 +248,8 @@
 				var/datum/sprite_accessory/tail/taur/tail = H.tail_style
 				src_message = tail.msg_prey_stepunder
 				tmob_message = tail.msg_owner_stepunder
+			if(tmob.is_incorporeal())	//RS Add Chomp port #7366 | CHOMPEdit - Nothing to step under. (dont step under phased kin)
+				return TRUE
 
 		if(src_message)
 			to_chat(src, "<span class='filter_notice'>[STEP_TEXT_OWNER(src_message)]</span>")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1654,6 +1654,7 @@
 #include "code\game\Rogue Star\kiss.dm"
 #include "code\game\Rogue Star\special_persist.dm"
 #include "code\game\Rogue Star\waddle.dm"
+#include "code\game\Rogue Star\_HELPERS\mobs.dm"
 #include "code\game\Rogue Star\catborgs\catborgs.dm"
 #include "code\game\Rogue Star\fluff\sari-outfit-fluff.dm"
 #include "code\game\turfs\simulated.dm"


### PR DESCRIPTION
Ported from the work of the legendary GUTI from chompstation.

fix: Step messages when stepping over a smaller, phased shadekin
fix: Shadekin catching items when phased
fix: Thrown item displaying messages and harming phased shadekin
fix: Slashing affecting phased shadekins
fix: Listening in, licking and smelling picking phased shadekin as targets
fix: Vines buckling phased shadekin
fix: Rogue vending machines targeting phased shadekin
fix: Mobs attacking phased shadekin
fix: Mobs eating laying down phased shadekin
fix: Thermals exposing phased shadekin
fix: Water and lava affecting phased shadekin
fix: Moving from space to station tile affecting phased shadekin
fix: Shadekin sliping on wet tiles
fix: Targeting a gun to a shadekin doesn't break when they phase out
fix: Phased shadekin squishing cockroaches
fix: Phased shadekin hallucinating if they stare at the SM

Future fixes in another PR: stopping kin from getting zapped by tesla, and probably other things awu.



https://github.com/CHOMPStation2/CHOMPStation2/pull/7366
https://github.com/CHOMPStation2/CHOMPStation2/pull/7484
https://github.com/CHOMPStation2/CHOMPStation2/pull/8267