### PR TITLE
Uncensors the podzu

### DIFF
--- a/code/modules/media/walkpod.dm
+++ b/code/modules/media/walkpod.dm
@@ -161,7 +161,7 @@
 
 // UI
 /obj/item/device/walkpod/proc/getTracksList()
-	return SSmedia_tracks.jukebox_tracks
+	return SSmedia_tracks.all_tracks
 
 /obj/item/device/walkpod/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
The Podzu is a personal device, why is it on the censored track list? Might as well unlock it- Especially since you can't hack the thing.