### PR TITLE
corrected method for detecting an AI shell

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -164,9 +164,11 @@
 
 	if(istype(W, /obj/item/device/mmi))
 		var/obj/item/device/mmi/M = W
-		if(isshell(user) && istype(W, /obj/item/device/mmi/inert/ai_remote))
-			to_chat(user, span_warning("Your hardware prohibits you from self-replicating."))
-			return
+		if(isrobot(user) && istype(W, /obj/item/device/mmi/inert/ai_remote)) //RS Edit
+			var/mob/living/silicon/robot/S = user //RS ADD
+			if(S.shell) //RS ADD
+				to_chat(user, span_warning("Your hardware prohibits you from self-replicating."))
+				return
 		if(check_completion())
 			if(!istype(loc,/turf))
 				to_chat(user, "<span class='warning'>You can't put \the [W] in, the frame has to be standing on the ground to be perfectly precise.</span>")


### PR DESCRIPTION
Replaced if(isshell(user) check which only checked the type for if its a shell with the inbuilt value that denotes an ai shell upon creation in the check for Inserting an ai control module