### PR TITLE
Add the art canvas's size into the canvas description

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -71,6 +71,7 @@
 /obj/item/canvas/Initialize()
 	. = ..()
 	reset_grid()
+	desc += " (Canvas size is [width]x[height].)" // RSEdit - Add canvas size into the canvas description
 
 /obj/item/canvas/proc/reset_grid()
 	grid = new/list(width,height)


### PR DESCRIPTION
Fairly simple, just adds the art canvases size in pixels into the canvas description in an easy way.