### PR TITLE
Fixes some runtimes in natural artist trait, simplifies the color selection process.

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -310,6 +310,10 @@
 		var/newcolor = input(user, "Select a new paint color:", "Paint Palette", P.selected_color) as null|color
 		if(newcolor && Adjacent(user, P) && Adjacent(user, src))
 			P.update_paint(newcolor)
+			if(istype(W, /obj/item/paint_brush/organic) && istype(user, /mob/living/carbon/human)) //RS Add, accounts for organic paintbrushes being used on palettes.
+				var/mob/living/carbon/human/H = user
+				P.color = newcolor
+				H.species.artist_color = newcolor //RS add End
 	else
 		return ..()
 

--- a/code/game/objects/structures/artstuff_rs.dm
+++ b/code/game/objects/structures/artstuff_rs.dm
@@ -21,7 +21,7 @@
 		P.update_paint(newcolor)
 		P.color = newcolor
 		if(istype(user, /mob/living/carbon/human))
-			user:species.artist_color = newcolor //Unsafe way to modify this, please only do with the above safety check if you copy this method.
+			creator.species.artist_color = newcolor
 		//to_chat(user, span_notice("[P] is now [newcolor]")) //debug
 	else
 		return ..()

--- a/code/game/objects/structures/artstuff_rs.dm
+++ b/code/game/objects/structures/artstuff_rs.dm
@@ -1,13 +1,28 @@
 /obj/item/paint_brush/organic
 	name = "organic paintbrush"
 	desc = "A 'paintbrush' made out of some form of organic material. Strange!"
-	description_info = "Click on yourself to change the color!"
+	description_info = "Click on brush to change the color!"
 	selected_color = "#000000"
 	force = 0
 	throwforce = 0
 	w_class = ITEMSIZE_HUGE
 	var/mob/living/carbon/human/creator
+	hud_level = TRUE
 
+/obj/item/paint_brush/organic/Initialize()
+	. = ..()
+	color_drop = image(icon, null, "brush_color")
+	color_drop.color = selected_color
+
+/obj/item/paint_brush/organic/attack_self(mob/living/user)
+	var/obj/item/paint_brush/organic/P = src
+	var/newcolor = input(user, "Select a new paint color:", "Paint Palette", P.selected_color) as null|color
+	if(newcolor)
+		P.update_paint(newcolor)
+		P.color = newcolor
+		//to_chat(user, span_notice("[P] is now [newcolor]")) //debug
+	else
+		return ..()
 /obj/item/paint_brush/organic/reset_plane_and_layer()
 	return //Unneeded. The object is deleted.
 
@@ -18,12 +33,13 @@
 		creator = loc
 
 /obj/item/paint_brush/organic/dropped(mob/user)
-	visible_message("[creator] puts their organic paintbrush back!")
-	if(creator.linked_brush) //Sanity, as it was runtiming during testing.
-		creator.linked_brush = null
-	spawn(1)
-		if(src)
-			qdel(src)
+	if(creator != null) // Insane in the membrane check, your below sanity check was causing runtimes when trying to change hands.
+		visible_message("[creator] puts their organic paintbrush back!")
+		if(creator.linked_brush) //Sanity, as it was runtiming during testing.
+			creator.linked_brush = null
+		spawn(1)
+			if(src)
+				qdel(src)
 
 /obj/item/paint_brush/organic/Destroy()
 	creator.linked_brush = null

--- a/code/game/objects/structures/artstuff_rs.dm
+++ b/code/game/objects/structures/artstuff_rs.dm
@@ -20,6 +20,8 @@
 	if(newcolor)
 		P.update_paint(newcolor)
 		P.color = newcolor
+		if(istype(user, /mob/living/carbon/human))
+			user:species.artist_color = newcolor //Unsafe way to modify this, please only do with the above safety check if you copy this method.
 		//to_chat(user, span_notice("[P] is now [newcolor]")) //debug
 	else
 		return ..()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1813,8 +1813,8 @@
 		if(linked_brush) //Do we have a paintbrush already?
 			linked_brush.update_paint(species.artist_color)
 			linked_brush.hud_layerise()
-			//linked_brush.color = species.artist_color
-*/
+			linked_brush.color = species.artist_color
+*/ //Removed and simplified to just click the brush
 /mob/living/carbon/human/proc/extend_retract_brush()
 	set name = "Conjure Natural Brush"
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1796,7 +1796,7 @@
 //RS ADD END
 
 //RS ADD
-/mob/living/carbon/human/proc/adjust_art_color()
+/*/mob/living/carbon/human/proc/adjust_art_color()
 	set name = "Adjust Artistic Color"
 	set category = "Abilities"
 	set desc = "Adjust what color you are currently painting with!"
@@ -1813,8 +1813,8 @@
 		if(linked_brush) //Do we have a paintbrush already?
 			linked_brush.update_paint(species.artist_color)
 			linked_brush.hud_layerise()
-			linked_brush.color = species.artist_color
-
+			//linked_brush.color = species.artist_color
+*/
 /mob/living/carbon/human/proc/extend_retract_brush()
 	set name = "Conjure Natural Brush"
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1119,12 +1119,14 @@
 	name = "Natural Artist"
 	desc = "Your body creates natural pigment or your fluids work like paint! You can paint without a paintbrush."
 	cost = 0
-	var_changes = list("nautral_artist" = TRUE)
+	custom_only = FALSE
+	var_changes = list("natural_artist" = TRUE)
 
 /datum/trait/neutral/natural_artist/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
-	H.verbs |= /mob/living/carbon/human/proc/adjust_art_color
+	//H.verbs |= /mob/living/carbon/human/proc/adjust_art_color //simplifying
 	H.verbs |= /mob/living/carbon/human/proc/extend_retract_brush
+
 
 /datum/trait/neutral/waddle
 	name = "Waddle / Animated Movement"


### PR DESCRIPTION
Original runtime occurred due to the trait being named "nautral artist" by accident, Corrected the typo.
Second runtime occurred if you tried to put the paintbrush in a different hand, which would cause the delete proc to fire off twice, and due to a null reference was causing another runtime.

Allows any species to take the perk, prommies, proteans, etc. you're all weird little paint goobers now.

Removed the verb "adjust_art_color" and added its functionality to just clicking on your paintbrush.

Added functionality of color shifting to the palette if youre using an organic brush, so you can dip your tails/fingers whatever into paint like a CREECHUR if you like.

Retained functionality of storing brush color between putting away / pulling out thanks to: https://github.com/TheGreatKitsune