### PR TITLE
20250227_1818_KH Remove 516 login warning.

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -24,9 +24,6 @@
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
 						log_adminwarn("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 
-		if (usr.client.byond_version > 515)
-			tgui_alert_async(usr, "You are running a beta client. There WILL be bugs. To avoid them, downgrade to the latest stable version, otherwise you are proceeding at your own risk. - Love, Kenzie", "WARNING!! WARNING!! WARNING!!", list("Don't tell me what to do I love bugs"))
-
 /mob/Login()
 
 	player_list |= src


### PR DESCRIPTION
Once https://github.com/TS-Rogue-Star/Rogue-Star/pull/809 is merged merge this too, while 516 is still a beta I don't really think it will be necessary to constantly warn people of this