### PR TITLE
Fixes Phased shadekin attacking things

### DIFF
--- a/code/modules/mob/living/simple_mob/combat.dm
+++ b/code/modules/mob/living/simple_mob/combat.dm
@@ -4,6 +4,8 @@
 
 	if(!A.Adjacent(src))
 		return ATTACK_FAILED
+	if(is_incorporeal()) //RS EDIT Stops phase shifted simples from attacking in phase?
+		return ATTACK_FAILED
 	var/turf/their_T = get_turf(A)
 
 	face_atom(A)

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -142,7 +142,8 @@
 		// If we're not hungry, call the sideways "parent" to do normal punching
 		if(!vore_active)
 			return ..()
-
+		if(is_incorporeal()) //RS EDIT Stops phase shifted simples from attacking in phase?
+			return
 		// If target is standing we might pounce and knock them down instead of attacking
 		var/pouncechance = CanPounceTarget(L)
 		if(pouncechance)


### PR DESCRIPTION
Added an is_incorporeal() check to simple mob ai to disable phased mobs (shadekin and whatever else might be using phase) from attacking players while in phase, Super simple.

I would LIKE to turn off combat AI while phased, but that is a PR for another time and more complicated than adding two lines.