### PR TITLE
Removes carried mobs from being used as access pass, micros included.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -218,6 +218,9 @@
 /mob/living/carbon/human/GetIdCard()
 	if(get_active_hand())
 		var/obj/item/I = get_active_hand()
+
+		if(!istype(I, /obj/item/weapon/card/id/))//RS Edit Removes simple mobs & Micros from being used as ID cards.
+			return null
 		var/id = I.GetID()
 		if(id)
 			return id


### PR DESCRIPTION
Disables you from picking up simple mobs that have access, or micros and using them as an ID card, ask the smalls to open door for you or take their ID.

Use either this or https://github.com/TS-Rogue-Star/Rogue-Star/pull/836