### PR TITLE
Fixes an issue with simple mob Put_in_hands()

### DIFF
--- a/code/modules/mob/living/simple_mob/hands.dm
+++ b/code/modules/mob/living/simple_mob/hands.dm
@@ -11,9 +11,17 @@
 	return
 
 /mob/living/simple_mob/put_in_hands(var/obj/item/W) // No hands.
-	if(has_hands)
-		put_in_active_hand(W)
-		return 1
+	if(has_hands) //RS Edit Start | Fixes simple mobs destroying ID's from PDAs'
+		if(put_in_active_hand(W))
+			update_inv_l_hand()
+			update_inv_r_hand()
+			return 1
+		else if(put_in_inactive_hand(W))
+			update_inv_l_hand()
+			update_inv_r_hand()
+			return 1
+		else
+			return ..() // RS Edit End
 	W.forceMove(get_turf(src))
 	return 1
 


### PR DESCRIPTION
Fixes simple mobs destroying items if they use functions similar to eject ID or Eject Pen with a full hand.

fixes #560 