### PR TITLE
Sets pets from pet system to not be devourable, two line addition.

### DIFF
--- a/code/modules/client/stored_mob.dm
+++ b/code/modules/client/stored_mob.dm
@@ -209,6 +209,7 @@
 	var/mob/living/simple_mob/M = new ourtype(get_turf(src))
 	M.mob_bank_load(user, load)
 	M.faction = user.faction
+	M.devourable = FALSE
 	M.desc += " It has a PET tag: \"[M.real_name]\", if lost, return to [user.real_name]."
 	M.revivedby = user.real_name
 	to_chat(user,"<span class = 'notice'>\The [M] appears from \the [src]!</span>")
@@ -401,6 +402,7 @@
 		var/mob/living/simple_mob/M = new ourtype(get_turf(src))
 		M.mob_bank_load(load = ourmob)
 		M.desc += " It has a PET tag: \"[M.real_name]\", it is registered as a station pet!"
+		M.devourable = FALSE
 		M.faction = "neutral"
 		M.ai_holder.hostile = FALSE
 		M.ai_holder.vore_hostile = FALSE


### PR DESCRIPTION
" From the Council of PETA (People eating tasty animals) We notice that your pet system is violating the ethics code of eating non sentient Beings, specifically, we had previously made it so that you cannot consume station pets such as Ian, lisa, or keindrick after repeated issues, and have devised a firmware update for this system.
As a result, All pets, regardless of who they belong to, are no longer Consumable. " <- Meme funny lore reason text.

Literally just makes pets from the pet system not eatable, requested by Headmin Kenzie, please do not smite me.