### PR TITLE
Minor Pet adjustments

### DIFF
--- a/code/game/objects/items/weapons/pet_carrier.dm
+++ b/code/game/objects/items/weapons/pet_carrier.dm
@@ -95,6 +95,12 @@
 		to_chat(user, SPAN_WARNING("You need to open [src]'s door!"))
 		return
 	var/size_diff = user.get_effective_size() - target.get_effective_size()
+	if(isanimal(target))	//RS EDIT START
+		var/mob/living/simple_mob/S = target
+		if(!(S.load_owner && S.load_owner != "seriouslydontsavethis" && S.load_owner = "STATION"))	//RS ADD - Is it someone's personal pet?
+			to_chat(user, SPAN_WARNING("\The [target] can't be picked up with \the [src]."))
+			return
+	//RS EDIT END
 	if(ishuman(target) && size_diff < 0.19)
 		to_chat(user, SPAN_WARNING("You get the feeling [target] is a tad too large for a [name]."))
 		return

--- a/code/game/objects/items/weapons/pet_carrier.dm
+++ b/code/game/objects/items/weapons/pet_carrier.dm
@@ -97,7 +97,7 @@
 	var/size_diff = user.get_effective_size() - target.get_effective_size()
 	if(isanimal(target))	//RS EDIT START - Check to see if it is a personal pet or otherwise restricted
 		var/mob/living/simple_mob/S = target
-		if(!(S.load_owner == "seriouslydontsavethis" || S.load_owner == "STATION"))
+		if(S.load_owner == "seriouslydontsavethis" || S.load_owner == "STATION")
 			to_chat(user, SPAN_WARNING("\The [target] can't be picked up with \the [src]."))
 			return
 	//RS EDIT END

--- a/code/game/objects/items/weapons/pet_carrier.dm
+++ b/code/game/objects/items/weapons/pet_carrier.dm
@@ -95,9 +95,9 @@
 		to_chat(user, SPAN_WARNING("You need to open [src]'s door!"))
 		return
 	var/size_diff = user.get_effective_size() - target.get_effective_size()
-	if(isanimal(target))	//RS EDIT START
+	if(isanimal(target))	//RS EDIT START - Check to see if it is a personal pet or otherwise restricted
 		var/mob/living/simple_mob/S = target
-		if(!(S.load_owner && S.load_owner != "seriouslydontsavethis" && S.load_owner = "STATION"))	//RS ADD - Is it someone's personal pet?
+		if(!(S.load_owner == "seriouslydontsavethis" || S.load_owner == "STATION"))
 			to_chat(user, SPAN_WARNING("\The [target] can't be picked up with \the [src]."))
 			return
 	//RS EDIT END

--- a/code/modules/awaymissions/redgate.dm
+++ b/code/modules/awaymissions/redgate.dm
@@ -41,8 +41,8 @@
 			keycheck = FALSE		//we'll allow it
 		if(isanimal(M))
 			var/mob/living/simple_mob/S = M
-			if(S.load_owner && S.load_owner != "seriouslydontsavethis" && load_owner = "STATION")	//RS ADD - Is it someone's personal pet?
-			keycheck = FALSE	//RS ADD - Then allow it
+			if(S.load_owner && S.load_owner != "seriouslydontsavethis" && S.load_owner = "STATION")	//RS ADD - Is it someone's personal pet?
+				keycheck = FALSE	//RS ADD - Then allow it
 		else return
 	if(!restrict_mobs || M.faction == "neutral" || M.faction == "pet")
 		keycheck = FALSE		//Probably a pet or something people will want to vibe with

--- a/code/modules/awaymissions/redgate.dm
+++ b/code/modules/awaymissions/redgate.dm
@@ -41,7 +41,7 @@
 			keycheck = FALSE		//we'll allow it
 		if(isanimal(M))
 			var/mob/living/simple_mob/S = M
-			if(S.load_owner && S.load_owner != "seriouslydontsavethis" && S.load_owner = "STATION")	//RS ADD - Is it someone's personal pet?
+			if(S.load_owner && S.load_owner != "seriouslydontsavethis" && S.load_owner == "STATION")	//RS ADD - Is it someone's personal pet?
 				keycheck = FALSE	//RS ADD - Then allow it
 		else return
 	if(!restrict_mobs || M.faction == "neutral" || M.faction == "pet")

--- a/code/modules/awaymissions/redgate.dm
+++ b/code/modules/awaymissions/redgate.dm
@@ -39,6 +39,10 @@
 	if(!isliving(M))		//We only want mob/living, no bullets or mechs or AI eyes or items
 		if(M.type in exceptions)
 			keycheck = FALSE		//we'll allow it
+		if(isanimal(M))
+			var/mob/living/simple_mob/S = M
+			if(S.load_owner && S.load_owner != "seriouslydontsavethis" && load_owner = "STATION")	//RS ADD - Is it someone's personal pet?
+			keycheck = FALSE	//RS ADD - Then allow it
 		else return
 	if(!restrict_mobs || M.faction == "neutral" || M.faction == "pet")
 		keycheck = FALSE		//Probably a pet or something people will want to vibe with

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother.dm
@@ -60,6 +60,9 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/intentional/giant_spider_broodmother
 	load_owner = "seriouslydontsavethis"	//RS ADD - It makes more mobs, please do not save this
 	devourable = FALSE	//RS ADD - They make more mobs, so let's not make them easy to carry around
+	pickup_pref = FALSE	//RS EDIT - See above, except this is relating to pet carriers
+	pickup_active = FALSE	//RS EDIT - See above
+
 	poison_per_bite = 2
 	poison_type = "cyanide"
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother.dm
@@ -58,6 +58,8 @@
 	special_attack_max_range = 10
 	special_attack_cooldown = 6 SECONDS
 	ai_holder_type = /datum/ai_holder/simple_mob/intentional/giant_spider_broodmother
+	load_owner = "seriouslydontsavethis"	//RS ADD - It makes more mobs, please do not save this
+	devourable = FALSE	//RS ADD - They make more mobs, so let's not make them easy to carry around
 	poison_per_bite = 2
 	poison_type = "cyanide"
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -45,8 +45,10 @@
 	To lay eggs, click a nearby tile. Laying eggs will deplete a charge."
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/nurse_spider
 
-	load_owner = "seriouslydontsavethis"	//RS ADD - It makes more mobs, please do not save this
-	devourable = FALSE	//RS ADD - They make more mobs, so let's not make them easy to carry around
+	load_owner = "seriouslydontsavethis"	//RS EDIT - It makes more mobs, please do not save this
+	devourable = FALSE	//RS EDIT - They make more mobs, so let's not make them easy to carry around
+	pickup_pref = FALSE	//RS EDIT - See above, except this is relating to pet carriers
+	pickup_active = FALSE	//RS EDIT - See above
 
 	var/fed = 0 // Counter for how many egg laying 'charges' the spider has.
 	var/laying_eggs = FALSE	// Only allow one set of eggs to be laid at once.

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -45,6 +45,9 @@
 	To lay eggs, click a nearby tile. Laying eggs will deplete a charge."
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/nurse_spider
 
+	load_owner = "seriouslydontsavethis"	//RS ADD - It makes more mobs, please do not save this
+	devourable = FALSE	//RS ADD - They make more mobs, so let's not make them easy to carry around
+
 	var/fed = 0 // Counter for how many egg laying 'charges' the spider has.
 	var/laying_eggs = FALSE	// Only allow one set of eggs to be laid at once.
 	var/egg_inject_chance = 25 // One in four chance to get eggs.

--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
@@ -82,6 +82,8 @@ var/list/_slime_default_emotes = list(
 
 	can_enter_vent_with = list(/obj/item/clothing/head)
 
+	devourable = FALSE	//RS EDIT - Slimes can be a pretty big force multiplier, so let's not make them super easy to carry around
+
 /mob/living/simple_mob/slime/get_available_emotes()
 	return global._slime_default_emotes.Copy()
 

--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
@@ -83,6 +83,8 @@ var/list/_slime_default_emotes = list(
 	can_enter_vent_with = list(/obj/item/clothing/head)
 
 	devourable = FALSE	//RS EDIT - Slimes can be a pretty big force multiplier, so let's not make them super easy to carry around
+	pickup_pref = FALSE	//RS EDIT - See above, except this is relating to pet carriers
+	pickup_active = FALSE	//RS EDIT - See above
 
 /mob/living/simple_mob/slime/get_available_emotes()
 	return global._slime_default_emotes.Copy()


### PR DESCRIPTION
Makes slimes, nurse spiders, and broodmothers not devourable by default.

Makes slimes, nurse spiders, and broodmothers not pick-up-able by default. This will prevent them from being picked up by pet carriers.

Also makes nurse spiders and broodmothers not able to be saved to the pet system. This will not affect existing pets, only new pet registrations.

Also, allows people's pets to pass through the redgate, so they can more easily bring their pets on adventures.