### PR TITLE
Port no touchy

### DIFF
--- a/code/__defines/species_traits.dm
+++ b/code/__defines/species_traits.dm
@@ -1,0 +1,7 @@
+//////flag defines specifically for species traits
+/// RS Port of Vorestation PULL #17289
+
+//touch reaction flags
+
+#define SPECIES_TRAIT_PATTING_DEFENCE 1
+#define SPECIES_TRAIT_PERSONAL_BUBBLE 2

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -429,19 +429,46 @@
 				t_him = "him"
 			if(FEMALE)
 				t_him = "her"
+	// RS Port of Vorestation PULL #17289 Start
+	if(target.touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE)
+		H.visible_message( \
+			span_notice("[target] moves to avoid being touched by [H]!"), \
+			span_notice("[target] moves to avoid being touched by you!"), )
+		return
+	// RS Port of Vorestation PULL #17289 End
 	//VOREStation Edit Start - Headpats and Handshakes.
 	if(H.zone_sel.selecting == "head")
-		H.visible_message( \
-			"<span class='notice'>[H] pats [target] on the head.</span>", \
-			"<span class='notice'>You pat [target] on the head.</span>", )
+		if(target.touch_reaction_flags & SPECIES_TRAIT_PATTING_DEFENCE) // RS Port of Vorestation PULL #17289 Start
+			H.visible_message( \
+				span_warning("[target] reflexively bites the hand of [H] to prevent head patting!"), \
+				span_warning("[target] reflexively bites your hand!"), )
+			log_and_message_admins("[src] pat [target], but they Bite!",src)
+			if(H.hand)
+				H.apply_damage(1, BRUTE, BP_L_HAND)
+			else
+				H.apply_damage(1, BRUTE, BP_R_HAND) // RS Port of Vorestation PULL #17289 End
+		else
+			H.visible_message( \
+				span_notice("[H] pats [target] on the head."), \
+				span_notice("You pat [target] on the head."), )
 	else if(H.zone_sel.selecting == "r_hand" || H.zone_sel.selecting == "l_hand")
 		H.visible_message( \
 			"<span class='notice'>[H] shakes [target]'s hand.</span>", \
 			"<span class='notice'>You shake [target]'s hand.</span>", )
 	else if(H.zone_sel.selecting == "mouth")
-		H.visible_message( \
-			"<span class='notice'>[H] boops [target]'s nose.</span>", \
-			"<span class='notice'>You boop [target] on the nose.</span>", )
+		if(target.touch_reaction_flags & SPECIES_TRAIT_PATTING_DEFENCE)// RS Port of Vorestation PULL #17289 Start
+			H.visible_message( \
+				span_warning("[target] reflexively bites the hand of [H] to prevent nose booping!"), \
+				span_warning("[target] reflexively bites your hand!"), )
+			log_and_message_admins("[src] pat [target], but they Bite!",src)
+			if(H.hand)
+				H.apply_damage(1, BRUTE, BP_L_HAND)
+			else
+				H.apply_damage(1, BRUTE, BP_R_HAND)// RS Port of Vorestation PULL #17289 End
+		else
+			H.visible_message( \
+				span_notice("[H] boops [target]'s nose."), \
+				span_notice("You boop [target] on the nose."), )
 	//VOREStation Edit End
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [t_him] feel better!</span>", \

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -442,7 +442,6 @@
 			H.visible_message( \
 				span_warning("[target] reflexively bites the hand of [H] to prevent head patting!"), \
 				span_warning("[target] reflexively bites your hand!"), )
-			log_and_message_admins("[src] pat [target], but they Bite!",src)
 			if(H.hand)
 				H.apply_damage(1, BRUTE, BP_L_HAND)
 			else
@@ -460,7 +459,6 @@
 			H.visible_message( \
 				span_warning("[target] reflexively bites the hand of [H] to prevent nose booping!"), \
 				span_warning("[target] reflexively bites your hand!"), )
-			log_and_message_admins("[src] pat [target], but they Bite!",src)
 			if(H.hand)
 				H.apply_damage(1, BRUTE, BP_L_HAND)
 			else

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1137,4 +1137,26 @@
 /datum/trait/neutral/waddle/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/waddle_adjust
+
+/datum/trait/neutral/patting_defence //RS Port of Vorestation PULL #17289
+	name = "Reflexive Biting"
+	desc = "You will reflexively bite hands that attempt to pat your head or boop your nose, this can be toggled off."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H) //RS Port of Vorestation PULL #17289
+	..()
+	H.touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
+	H.verbs |= /mob/living/proc/toggle_patting_defence
+
+/datum/trait/neutral/personal_space //RS Port of Vorestation PULL #17289
+	name = "Personal Space Bubble"
+	desc = "You are adept at avoiding unwanted physical contact and dodge it with ease. You will reflexively dodge any attempt to hug, pat, boop, lick, sniff you or even shake your hand, this can be toggled off."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H) //RS Port of Vorestation PULL #17289
+	..()
+	H.touch_reaction_flags |= SPECIES_TRAIT_PERSONAL_BUBBLE
+	H.verbs |= /mob/living/proc/toggle_personal_space
 //RS Edit End

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1155,7 +1155,7 @@
 	cost = 0
 	custom_only = FALSE
 
-/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H) //RS Port of Vorestation PULL #17289
+/datum/trait/neutral/personal_space/apply(var/datum/species/S,var/mob/living/carbon/human/H) //RS Port of Vorestation PULL #17289
 	..()
 	H.touch_reaction_flags |= SPECIES_TRAIT_PERSONAL_BUBBLE
 	H.verbs |= /mob/living/proc/toggle_personal_space

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -83,3 +83,5 @@
 	var/datum/inventory_panel/inventory_panel
 	var/last_resist_time = 0 // world.time of the most recent resist that wasn't on cooldown.
 	var/tiredness = 0 //For vore draining // RS Edit || Ports VOREStation PR15876
+
+	var/touch_reaction_flags // RS Port of Vorestation PULL #17289

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -34,19 +34,19 @@
 /mob/living/proc/toggle_patting_defence() // RS Port of Vorestation PULL #17289
 	set name = "Toggle Reflexive Biting"
 	set desc = "Toggles the automatic biting for if someone pats you on the head or boops your nose."
-	set category = "Abilities.General"
+	set category = "Abilities"
 
 	if(touch_reaction_flags & SPECIES_TRAIT_PATTING_DEFENCE)
 		touch_reaction_flags &= ~(SPECIES_TRAIT_PATTING_DEFENCE)
 		to_chat(src,span_notice("You will no longer bite hands who pat or boop you."))
 	else
 		touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
-		to_chat(src,span_notice("You will now longer bite hands who pat or boop you."))
+		to_chat(src,span_notice("You will now bite hands who pat or boop you."))
 
 /mob/living/proc/toggle_personal_space() // RS Port of Vorestation PULL #17289
 	set name = "Toggle Personal Space"
 	set desc = "Toggles dodging any attempts to hug or pat you."
-	set category = "Abilities.General"
+	set category = "Abilities"
 
 	if(touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE)
 		touch_reaction_flags &= ~(SPECIES_TRAIT_PERSONAL_BUBBLE)

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -30,3 +30,27 @@
 
 	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
 	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")
+
+/mob/living/proc/toggle_patting_defence() // RS Port of Vorestation PULL #17289
+	set name = "Toggle Reflexive Biting"
+	set desc = "Toggles the automatic biting for if someone pats you on the head or boops your nose."
+	set category = "Abilities.General"
+
+	if(touch_reaction_flags & SPECIES_TRAIT_PATTING_DEFENCE)
+		touch_reaction_flags &= ~(SPECIES_TRAIT_PATTING_DEFENCE)
+		to_chat(src,span_notice("You will no longer bite hands who pat or boop you."))
+	else
+		touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
+		to_chat(src,span_notice("You will now longer bite hands who pat or boop you."))
+
+/mob/living/proc/toggle_personal_space() // RS Port of Vorestation PULL #17289
+	set name = "Toggle Personal Space"
+	set desc = "Toggles dodging any attempts to hug or pat you."
+	set category = "Abilities.General"
+
+	if(touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE)
+		touch_reaction_flags &= ~(SPECIES_TRAIT_PERSONAL_BUBBLE)
+		to_chat(src,span_notice("You will no longer dodge all attempts at hugging, patting, booping, licking, smelling and hand shaking."))
+	else
+		touch_reaction_flags |= SPECIES_TRAIT_PERSONAL_BUBBLE
+		to_chat(src,span_notice("You will now dodge all attempts at hugging, patting, booping, licking, smelling and hand shaking."))

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -401,7 +401,6 @@
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if((tasted.touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE) && (!tasted.grabbed_by.len || !tasted.stat)) // RS Port of Vorestation PULL #17289
 		visible_message(span_warning("[src] tries to lick [tasted], but they dodge out of the way!"),span_warning("You try to lick [tasted], but they deftly avoid your attempt."))
-		log_and_message_admins("[src] tries to lick [tasted], but they dodge out of the way!",src)
 		return
 	visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
 
@@ -444,7 +443,6 @@
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if((smelled.touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE) && (!smelled.grabbed_by.len || !smelled.stat)) // RS Port of Vorestation PULL #17289
 		visible_message(span_warning("[src] tries to smell [smelled], but they dodge out of the way!"),span_warning("You try to smell [smelled], but they deftly avoid your attempt."))
-		log_and_message_admins("[src] tries to smell [smelled], but they dodge out of the way!",src)
 		return
 	visible_message("<span class='warning'>[src] smells [smelled]!</span>","<span class='notice'>You smell [smelled]. They smell like [smelled.get_smell_message()].</span>","<b>Sniff!</b>")
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -399,7 +399,10 @@
 		return
 
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-
+	if((tasted.touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE) && (!tasted.grabbed_by.len || !tasted.stat)) // RS Port of Vorestation PULL #17289
+		visible_message(span_warning("[src] tries to lick [tasted], but they dodge out of the way!"),span_warning("You try to lick [tasted], but they deftly avoid your attempt."))
+		log_and_message_admins("[src] tries to lick [tasted], but they dodge out of the way!",src)
+		return
 	visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
 
 
@@ -439,6 +442,10 @@
 		return
 
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if((smelled.touch_reaction_flags & SPECIES_TRAIT_PERSONAL_BUBBLE) && (!smelled.grabbed_by.len || !smelled.stat)) // RS Port of Vorestation PULL #17289
+		visible_message(span_warning("[src] tries to smell [smelled], but they dodge out of the way!"),span_warning("You try to smell [smelled], but they deftly avoid your attempt."))
+		log_and_message_admins("[src] tries to smell [smelled], but they dodge out of the way!",src)
+		return
 	visible_message("<span class='warning'>[src] smells [smelled]!</span>","<span class='notice'>You smell [smelled]. They smell like [smelled.get_smell_message()].</span>","<b>Sniff!</b>")
 
 /mob/living/proc/get_smell_message(allow_generic = 1)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -94,6 +94,7 @@
 #include "code\__defines\span_vr.dm"
 #include "code\__defines\species_languages.dm"
 #include "code\__defines\species_languages_vr.dm"
+#include "code\__defines\species_traits.dm"
 #include "code\__defines\sprite_sheets.dm"
 #include "code\__defines\sqlite_defines.dm"
 #include "code\__defines\stat_tracking.dm"


### PR DESCRIPTION
Ports and corrects a few issues with: https://github.com/VOREStation/VOREStation/pull/17289
Description: adds two traits "Reflexive biting" and "personal space" that allows you to toggle the ability to be:
Personal space: Prevents all touching, smelling, headpats, noseboops, etc, while active. 
Can be toggled on and off with "Toggle personal space"

Reflexive Biting: Prevents nose booping and headpats Specifically, causes 1 Brute damage and a funny bite message.
Can be toggled on and off with "Toggle Reflexive Biting"