### PR TITLE
Electrovore & Electrovore, Obligate

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -22,7 +22,7 @@
 	var/bloodsucker = FALSE // Allows safely getting nutrition from blood.
 	var/bloodsucker_controlmode = "always loud" //Allows selecting between bloodsucker control modes. Always Loud corresponds to original implementation.
 
-	var/electrovore = FALSE // Allows the ability to drain power cells of energy to give nutrition
+	var/electrovore = FALSE //RS Add: Allows the ability to drain power cells of energy to give nutrition
 
 	var/is_weaver = FALSE
 	var/silk_production = FALSE

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -22,6 +22,8 @@
 	var/bloodsucker = FALSE // Allows safely getting nutrition from blood.
 	var/bloodsucker_controlmode = "always loud" //Allows selecting between bloodsucker control modes. Always Loud corresponds to original implementation.
 
+	var/electrovore = FALSE // Allows the ability to drain power cells of energy to give nutrition
+
 	var/is_weaver = FALSE
 	var/silk_production = FALSE
 	var/silk_reserve = 100

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1135,4 +1135,20 @@
 /datum/trait/neutral/waddle/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/waddle_adjust
+
+/datum/trait/neutral/electrovore
+	name = "Electrovore, Obligate"
+	desc = "Makes you unable to gain nutrition from anything but electricity. To compenstate, you are able to drain energy from power cells."
+	tutorial = "This trait forces you to only consume electricity - you cannot have normal food anymore. Vore is, of course, an exception! <br> \
+		You can satisfy this by clicking power cells in your hand on harm intent, and you can even recharge them by using help intent! <br> \
+		Intent-based control scheme: <br> \
+		HELP - recharge powercell in hand <br> \
+		HARM - drain power cell in hand"
+
+	cost = 0
+	can_take = ORGANICS
+	custom_only = FALSE
+	var_changes = list("organic_food_coeff" = 0, "electrovore" = TRUE)
+	// excludes = list(/datum/trait/neutral/bloodsucker_freeform)
+
 //RS Edit End

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1137,6 +1137,19 @@
 	H.verbs |= /mob/living/proc/waddle_adjust
 
 /datum/trait/neutral/electrovore
+	name = "Electrovore"
+	desc = "Allows you to drain power cells for nutrition."
+	tutorial = "This trait allows you to consume electricity! <br> \
+		You can do this by clicking power cells in your hand on harm intent. <br> \
+		Intent-based control scheme: <br> \
+		HARM - drain power cell in hand"
+
+	cost = 0
+	custom_only = FALSE
+	var_changes = list("electrovore" = TRUE)
+	excludes = list(/datum/trait/neutral/electrovore_obligate)
+
+/datum/trait/neutral/electrovore_obligate
 	name = "Electrovore, Obligate"
 	desc = "Makes you unable to gain nutrition from anything but electricity. To compenstate, you are able to drain energy from power cells."
 	tutorial = "This trait forces you to only consume electricity - you cannot have normal food anymore. Vore is, of course, an exception! <br> \
@@ -1146,9 +1159,8 @@
 		HARM - drain power cell in hand"
 
 	cost = 0
-	can_take = ORGANICS
 	custom_only = FALSE
 	var_changes = list("organic_food_coeff" = 0, "electrovore" = TRUE)
-	// excludes = list(/datum/trait/neutral/bloodsucker_freeform)
+	excludes = list(/datum/trait/neutral/electrovore)
 
 //RS Edit End

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -22,6 +22,9 @@
 	if(batterylicker.a_intent == I_HURT)
 		user.show_message("<span class='warning'>Sparks fly from \the [src] as you drain energy from it!</span>")
 		user.visible_message("<font color='red'>[user] causes sparks to emit from \the [src] as it loses its charge!</font>")
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(3, 0, src)
+		s.start()
 		var/totransfer = min(charge,1500)
 		batterylicker.adjust_nutrition((totransfer / 15) * coefficient)
 		use(totransfer)

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -12,12 +12,15 @@
 		// Charge the battery
 		user.show_message("<span class='warning'>Power surges from your fingertips and flows into \the [src], increasing its charge!</span>")
 		user.visible_message("<font color='white'>[user] squeezes \the [src] tightly, and charges it!</font>")
-		var/totransfer = batterylicker.adjust_nutrition(-(min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15))))
-		give(min(abs(totransfer * 15), maxcharge))
+		var/totransfer = min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15))
+		// Takes 20% of normal nutrition (100 of a total of 500 for normal characters) or 20% of current nutrition if above the normal cap
+		// Minimum hardcaps at remaining space in the battery, converted to the nutrition equivalent for comparison
+		batterylicker.adjust_nutrition(-totransfer)
+		give(min((totransfer * 15), (maxcharge - charge))) // Compares against remaining space in case of a rounding error
 		update_icon()
 		return
 
-	if(!charge) // May need conditionals for low power situations
+	if(!charge)
 		batterylicker.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
 		return
 	if(batterylicker.a_intent == I_HURT)

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/cell/attack_self(mob/living/user as mob)
-	var/coefficient = 1 // Available to adjust later if needed, adding in a loss on top of how much it drains from the battery feels like a bit much.
+	var/coefficient = 1 // Available to adjust later if needed, adding in a loss on top of how much it drains your nutrition to refill the battery feels like a bit much.
 // User must be an Electrovore, the cell must have power, and the intent must be set to harm or help when used in hand
 	if(!ishuman(user))
 		return
@@ -8,9 +8,11 @@
 		return
 	if(!maxcharge)
 		return
-	if(batterylicker.a_intent == I_HELP)
+	if(batterylicker.a_intent == I_HELP && batterylicker.species.organic_food_coeff == 0)
 		// Charge the battery
-		var/totransfer = batterylicker.adjust_nutrition(min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15)))
+		user.show_message("<span class='warning'>Power surges from your fingertips and flows into \the [src], increasing its charge!</span>")
+		user.visible_message("<font color='white'>[user] squeezes \the [src] tightly, and charges it!</font>")
+		var/totransfer = batterylicker.adjust_nutrition(-(min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15))))
 		give(min((totransfer * 15), maxcharge))
 		update_icon()
 
@@ -18,6 +20,8 @@
 		batterylicker.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
 		return
 	if(batterylicker.a_intent == I_HURT)
+		user.show_message("<span class='warning'>Sparks fly from \the [src] as you drain energy from it!</span>")
+		user.visible_message("<font color='red'>[user] causes sparks to emit from \the [src] as it loses its charge!</font>")
 		var/totransfer = min(charge,1500)
 		batterylicker.adjust_nutrition((totransfer / 15) * coefficient)
 		use(totransfer)

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -1,0 +1,24 @@
+/obj/item/weapon/cell/attack_self(mob/living/user as mob)
+	var/coefficient = 1 // Available to adjust later if needed, adding in a loss on top of how much it drains from the battery feels like a bit much.
+// User must be an Electrovore, the cell must have power, and the intent must be set to harm or help when used in hand
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/batterylicker = user
+	if(!batterylicker.species.electrovore)
+		return
+	if(!maxcharge)
+		return
+	if(batterylicker.a_intent == I_HELP)
+		// Charge the battery
+		var/totransfer = batterylicker.adjust_nutrition(min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15)))
+		give(min((totransfer * 15), maxcharge))
+		update_icon()
+
+	if(!charge) // May need conditionals for low power situations
+		batterylicker.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
+		return
+	if(batterylicker.a_intent == I_HURT)
+		var/totransfer = min(charge,1500)
+		batterylicker.adjust_nutrition((totransfer / 15) * coefficient)
+		use(totransfer)
+		update_icon()

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -13,8 +13,9 @@
 		user.show_message("<span class='warning'>Power surges from your fingertips and flows into \the [src], increasing its charge!</span>")
 		user.visible_message("<font color='white'>[user] squeezes \the [src] tightly, and charges it!</font>")
 		var/totransfer = batterylicker.adjust_nutrition(-(min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15))))
-		give(min((totransfer * 15), maxcharge))
+		give(min(abs(totransfer * 15), maxcharge))
 		update_icon()
+		return
 
 	if(!charge) // May need conditionals for low power situations
 		batterylicker.show_message("<span class='warning'>You take a look at \the [src] and notice it has nothing in it!</span>")
@@ -22,10 +23,10 @@
 	if(batterylicker.a_intent == I_HURT)
 		user.show_message("<span class='warning'>Sparks fly from \the [src] as you drain energy from it!</span>")
 		user.visible_message("<font color='red'>[user] causes sparks to emit from \the [src] as it loses its charge!</font>")
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 0, src)
-		s.start()
 		var/totransfer = min(charge,1500)
 		batterylicker.adjust_nutrition((totransfer / 15) * coefficient)
 		use(totransfer)
 		update_icon()
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(3, 0, src)
+		s.start()

--- a/code/modules/power/cell_rs.dm
+++ b/code/modules/power/cell_rs.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/cell/attack_self(mob/living/user as mob)
-	var/coefficient = 1 // Available to adjust later if needed, adding in a loss on top of how much it drains your nutrition to refill the battery feels like a bit much.
+	var/coefficient = 0.9 // Available to adjust later if needed, adding in more than a 10% loss on top of how much it drains your nutrition to refill the battery feels like a bit much.
 // User must be an Electrovore, the cell must have power, and the intent must be set to harm or help when used in hand
 	if(!ishuman(user))
 		return
@@ -8,14 +8,17 @@
 		return
 	if(!maxcharge)
 		return
-	if(batterylicker.a_intent == I_HELP && batterylicker.species.organic_food_coeff == 0)
+	if(batterylicker.a_intent == I_HELP && batterylicker.species.organic_food_coeff == 0 && batterylicker.nutrition)
 		// Charge the battery
-		user.show_message("<span class='warning'>Power surges from your fingertips and flows into \the [src], increasing its charge!</span>")
+		if(charge == maxcharge)
+			return
+		user.show_message("<span class='warning'>Power surges from you and flows into \the [src], increasing its charge!</span>")
 		user.visible_message("<font color='white'>[user] squeezes \the [src] tightly, and charges it!</font>")
 		var/totransfer = min(max(100, (batterylicker.nutrition * 0.2)), ((maxcharge - charge) / 15))
+		var/todrain = max(100, (batterylicker.nutrition * 0.2))
 		// Takes 20% of normal nutrition (100 of a total of 500 for normal characters) or 20% of current nutrition if above the normal cap
 		// Minimum hardcaps at remaining space in the battery, converted to the nutrition equivalent for comparison
-		batterylicker.adjust_nutrition(-totransfer)
+		batterylicker.adjust_nutrition(-todrain)
 		give(min((totransfer * 15), (maxcharge - charge))) // Compares against remaining space in case of a rounding error
 		update_icon()
 		return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3641,6 +3641,7 @@
 #include "code\modules\power\cable_ender.dm"
 #include "code\modules\power\cable_heavyduty.dm"
 #include "code\modules\power\cell.dm"
+#include "code\modules\power\cell_rs.dm"
 #include "code\modules\power\debug_items.dm"
 #include "code\modules\power\generator.dm"
 #include "code\modules\power\gravitygenerator_vr.dm"


### PR DESCRIPTION
Adds the traits for Electrovore and Electrovore, Obligate, allowing both to drain power cells for nutrition. On top of that, Obligates are able to use their nutrition in order to charge power cells - at a minor loss of nutrition. 

This is balanced around Bloodsucker, with the blood bags falling - nutrition-wise - between High and Super capacity power cells, meaning if you want the really filling ones you either need to get very lucky, or ask Research. 

Electrovore and Electrovore, Obligate are mutually exclusive. 

Credit to ZayahPapaya for teaching and assisting.