### PR TITLE
add stairs as floor decals

### DIFF
--- a/code/game/turfs/flooring/flooring_decals_vr.dm
+++ b/code/game/turfs/flooring/flooring_decals_vr.dm
@@ -471,12 +471,12 @@
 	icon_state = "center_lines"
 
 //RS add - fake stairs decals
-/obj/effect/floor_decal/shortstairs
+/obj/effect/floor_decal/fakestairs
 	icon = 'icons/turf/structures.dmi'
-	name = "short stairs"
+	name = "fake stairs"
 
-/obj/effect/floor_decal/shortstairs/top
+/obj/effect/floor_decal/fakestairs/top
 	icon_state = "ramptop"
-/obj/effect/floor_decal/shortstairs/bottom
+/obj/effect/floor_decal/fakestairs/bottom
 	icon_state = "rampbottom"
 //end RS add

--- a/code/game/turfs/flooring/flooring_decals_vr.dm
+++ b/code/game/turfs/flooring/flooring_decals_vr.dm
@@ -469,3 +469,14 @@
 
 /obj/effect/floor_decal/road/center
 	icon_state = "center_lines"
+
+//RS add - fake stairs decals
+/obj/effect/floor_decal/shortstairs
+	icon = 'icons/turf/structures.dmi'
+	name = "short stairs"
+
+/obj/effect/floor_decal/shortstairs/top
+	icon_state = "ramptop"
+/obj/effect/floor_decal/shortstairs/bottom
+	icon_state = "rampbottom"
+//end RS add


### PR DESCRIPTION
Adds decorative stairs as something you can put on the floor. Called 'shortstairs' in the files. I don't know what happened to the previous implementation but I cannot find it anywhere, so here's a new implementation.