### PR TITLE
Fix C-Reg Pixel Shift on Dismantle

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -476,14 +476,14 @@ Class Procs:
 		A.state = FRAME_WIRED
 
 	A.set_dir(dir)
-	A.pixel_x = 0 //RS Edit: Shift the frame back to the center
-	A.pixel_y = 0 //RS Edit: Shift the frame back to the center
+	A.pixel_x = pixel_x
+	A.pixel_y = pixel_y
 	A.update_desc()
 	A.update_icon()
 	M.loc = null
 	M.deconstruct(src)
 	qdel(src)
-	return 1
+	return A //RS Edit: Return the frame
 
 /obj/machinery/bullet_act(obj/item/projectile/P, def_zone)
 	. = ..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -476,8 +476,8 @@ Class Procs:
 		A.state = FRAME_WIRED
 
 	A.set_dir(dir)
-	A.pixel_x = 0
-	A.pixel_y = 0
+	A.pixel_x = 0 //RS Edit: Shift the frame back to the center
+	A.pixel_y = 0 //RS Edit: Shift the frame back to the center
 	A.update_desc()
 	A.update_icon()
 	M.loc = null

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -476,8 +476,8 @@ Class Procs:
 		A.state = FRAME_WIRED
 
 	A.set_dir(dir)
-	A.pixel_x = pixel_x
-	A.pixel_y = pixel_y
+	A.pixel_x = 0
+	A.pixel_y = 0
 	A.update_desc()
 	A.update_icon()
 	M.loc = null

--- a/code/modules/power/port_gen_vr.dm
+++ b/code/modules/power/port_gen_vr.dm
@@ -438,6 +438,12 @@
 	default_power_gen = 500000 //Half power
 	nutrition_drain = 0.5	//for half cost - EQUIVALENT EXCHANGE >:O
 
+/obj/machinery/power/rtg/reg/dismantle()  //RS Add: Give it it's own dismantle so it can fix the location
+	. = ..()
+	var/obj/structure/frame/F = .
+	if(istype(F, /obj/structure/frame))
+		F.pixel_x = 0
+		F.pixel_y = 0
 
 // Big altevian version of pacman. has a lot of copypaste from regular kind, but less flexible.
 /obj/machinery/power/port_gen/large_altevian


### PR DESCRIPTION
Fixes a pixel shift bug when dismantling the c-reg.

Resolves https://github.com/TS-Rogue-Star/Rogue-Star/issues/193

Verified this works, but marking this as draft until someone can verify this doesn't break anything else.

Removing draft label.  Soft taught me how to use the wacky . = ..() stuff so I made it better.