### PR TITLE
Add chameleon blend in trait, also signal work

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -779,3 +779,7 @@
 	#define ELEMENT_CONFLICT_FOUND	(1<<0)
 //From reagents touch_x.
 #define COMSIG_REAGENTS_TOUCH "reagent_touch"
+//RS ADD START
+#define COMSIG_FACE_ATOM "face_atom"
+#define COMSIG_GET_ATTACK_SPEED "get_attack_speed"
+//RS ADD END

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -346,6 +346,7 @@
 
 // Simple helper to face what you clicked on, in case it should be needed in more than one place
 /mob/proc/face_atom(var/atom/A)
+	SEND_SIGNAL(src,COMSIG_FACE_ATOM)	//RS ADD
 	if(!A || !x || !y || !A.x || !A.y) return
 	var/dx = A.x - x
 	var/dy = A.y - y

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -79,6 +79,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 // Same as above but actually does useful things.
 // W is the item being used in the attack, if any. modifier is if the attack should be longer or shorter than usual, for whatever reason.
 /mob/living/get_attack_speed(var/obj/item/W)
+	SEND_SIGNAL(src,COMSIG_GET_ATTACK_SPEED)	//RS ADD
 	var/speed = base_attack_cooldown
 	if(W && istype(W))
 		speed = W.attackspeed

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -233,8 +233,17 @@
 		return FALSE
 
 	if(respect_alpha && the_target.alpha <= alpha_vision_threshold) // Fake invis.
-		ai_log("can_see_target() : Target ([the_target]) was sufficently transparent to holder and is hidden. Exiting.", AI_LOG_TRACE)
-		return FALSE
+		var/hidden = TRUE	//RS ADD START - Sneaky, but not that sneaky. >:O
+		if(isliving(the_target))
+			var/mob/living/L = the_target
+			for(var/datum/modifier/M in L.modifiers)
+				if(M.type == /datum/modifier/blend_in)
+					var/datum/modifier/blend_in/B = M
+					if(B.chargup < 4)
+						hidden = FALSE
+		if(hidden)	//RS ADD END
+			ai_log("can_see_target() : Target ([the_target]) was sufficently transparent to holder and is hidden. Exiting.", AI_LOG_TRACE)
+			return FALSE
 
 	if(get_dist(holder, the_target) > view_range) // Too far away.
 		ai_log("can_see_target() : Target ([the_target]) was too far from holder. Exiting.", AI_LOG_TRACE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -269,6 +269,8 @@
 /mob/living/carbon/human/proc/get_visible_name()
 	if(ability_flags & AB_PHASE_SHIFTED)
 		return "Something"	// Something
+	if(alpha <= EFFECTIVE_INVIS)	//RS ADD - You're basically invisible lol
+		return "Unknown"	//RS ADD
 	if( wear_mask && (wear_mask.flags_inv&HIDEFACE) )	//Wearing a mask which hides our face, use id-name if possible
 		return get_id_name("Unknown")
 	if( head && (head.flags_inv&HIDEFACE) )

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -26,6 +26,9 @@
 
 	if(status_flags & GODMODE)	return 0	//godmode
 
+	if(amount > 0)	//RS ADD
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
+
 	if(should_have_organ("brain"))
 		var/obj/item/organ/internal/brain/sponge = internal_organs_by_name["brain"]
 		if(sponge)
@@ -113,6 +116,7 @@
 /mob/living/carbon/human/adjustBruteLoss(var/amount,var/include_robo)
 	amount = amount*species.brute_mod
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -135,6 +139,7 @@
 /mob/living/carbon/human/adjustFireLoss(var/amount,var/include_robo)
 	amount = amount*species.burn_mod
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -159,6 +164,7 @@
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
+			SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 			for(var/datum/modifier/M in modifiers)
 				if(!isnull(M.incoming_damage_percent))
 					if(M.energy_based)
@@ -185,6 +191,7 @@
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
+			SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 			for(var/datum/modifier/M in modifiers)
 				if(!isnull(M.incoming_damage_percent))
 					if(M.energy_based)
@@ -261,6 +268,7 @@
 	var/heal_prob = max(0, 80 - getCloneLoss())
 	var/mut_prob = min(80, getCloneLoss()+10)
 	if (amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		if (prob(mut_prob))
 			var/list/obj/item/organ/external/candidates = list()
 			for (var/obj/item/organ/external/O in organs)
@@ -297,6 +305,8 @@
 		oxyloss = 0
 	else
 		amount = amount*species.oxy_mod
+		if(amount > 0)	//RS ADD
+			SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		..(amount)
 
 /mob/living/carbon/human/setOxyLoss(var/amount)
@@ -310,6 +320,7 @@
 		halloss = 0
 	else
 		if(amount > 0)	//only multiply it by the mod if it's positive, or else it takes longer to fade too!
+			SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 			amount = amount*species.pain_mod
 		..(amount)
 
@@ -329,6 +340,8 @@
 		toxloss = 0
 	else
 		amount = amount*species.toxins_mod
+		if(amount > 0)	//RS ADD
+			SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		..(amount)
 
 /mob/living/carbon/human/setToxLoss(var/amount)
@@ -468,7 +481,7 @@ This function restores all organs.
 /mob/living/carbon/human/apply_damage(var/damage = 0, var/damagetype = BRUTE, var/def_zone = null, var/blocked = 0, var/soaked = 0, var/sharp = FALSE, var/edge = FALSE, var/obj/used_weapon = null)
 	if(Debug2)
 		to_world_log("## DEBUG: human/apply_damage() was called on [src], with [damage] damage, an armor value of [blocked], and a soak value of [soaked].")
-
+	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 	var/obj/item/organ/external/organ = null
 	if(isorgan(def_zone))
 		organ = def_zone

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -1,0 +1,65 @@
+//RS FILE
+/mob/living/proc/chameleon_blend()
+	set name = "Blend In"
+	set category = "Abilities"
+	set desc = "Stand still to blend in!"
+
+	if(stat || paralysis || weakened || stunned || world.time < last_special)
+		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
+		return
+
+	if(alpha < 255)
+		to_chat(src, "<span class='warning'>You seem to already be blending in, silly!</span>")
+		return
+
+	last_special = world.time + 5 SECONDS	//Please do not spam ty ilu
+
+	if(!istype(src, /mob/living))	//How did you get here!!!
+		to_chat(src, "<span class='warning'>It doesn't work that way.</span>")
+		return
+
+	add_modifier(/datum/modifier/blend_in)	//The meat happens with a modifier baby!!!
+	playsound(src, 'sound/effects/EMPulse.ogg', 75, 1)
+	return TRUE
+
+/datum/modifier/blend_in	//The magic happens here
+	name = "Blend In"
+	desc = "Blending in!"
+
+	on_created_text = "<span class='notice'>Your body's color changes to blend in with your surroundings! As long as you stay still, you should blend in!</span>"
+	on_expired_text = "<span class='notice'>Your body's colors return to normal!</span>"
+
+	stacks = MODIFIER_STACK_FORBID	//Don't blend while blending pls and thank you
+	var/chargup = 0
+
+/datum/modifier/blend_in/New()
+	. = ..()
+	var/turf/T = get_turf(holder)
+	animate(holder, (5 * T.get_lumcount()) SECONDS ,alpha = 10)	//Animate uses the client to interpolate, so this saves server power~
+	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(expire), TRUE)	//Let's listen for our mob to say it moved! If it does, then we expire!
+	RegisterSignal(holder, COMSIG_MOB_APPLY_DAMGE, PROC_REF(expire), TRUE)	//Let's listen for our mob to take damage! If it does, then we expire!
+	RegisterSignal(holder, COMSIG_GET_ATTACK_SPEED, PROC_REF(expire), TRUE)	//Don't move!!!
+	RegisterSignal(holder, COMSIG_ITEM_PRE_ATTACK, PROC_REF(expire), TRUE)	//Don't move!!!
+	RegisterSignal(holder, COMSIG_MOB_FIRED_GUN, PROC_REF(expire), TRUE)	//Stop blending in when you shoot people
+	holder.plane = -26
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		name = H.get_visible_name()
+
+/datum/modifier/blend_in/tick()
+	. = ..()
+	holder.last_special = world.time + 5 SECONDS	//Update the cooldown! This happens every 2 seconds or so~
+	chargup ++
+
+/datum/modifier/blend_in/expire()
+	. = ..()
+	animate(holder, 1 SECOND , alpha = 255)	//Animate your alpha back to normal
+	UnregisterSignal(holder, COMSIG_MOVABLE_MOVED)	//Cleanup your signals!
+	UnregisterSignal(holder, COMSIG_MOB_APPLY_DAMGE)	//Cleanup your signals!
+	UnregisterSignal(holder, COMSIG_GET_ATTACK_SPEED)	//Cleanup your signals!
+	UnregisterSignal(holder, COMSIG_ITEM_PRE_ATTACK)	//Cleanup your signals!
+	UnregisterSignal(holder, COMSIG_MOB_FIRED_GUN)	//Cleanup your signals!
+	holder.plane = initial(holder.plane)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		name = H.get_visible_name()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -19,7 +19,7 @@
 		return
 
 	add_modifier(/datum/modifier/blend_in)	//The meat happens with a modifier baby!!!
-	playsound(src, 'sound/effects/EMPulse.ogg', 75, 1)
+	playsound(src, 'sound/effects/basscannon.ogg', 5, 1)
 	return TRUE
 
 /datum/modifier/blend_in	//The magic happens here

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -4,12 +4,23 @@
 	set category = "Abilities"
 	set desc = "Stand still to blend in!"
 
-	if(stat || paralysis || weakened || stunned || world.time < last_special)
+	if(world.time < last_special)
+		to_chat(src, "<span class='warning'>You can't do that yet!</span>")
+		return
+
+	if(stat || paralysis || weakened || stunned)
 		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
 		return
 
 	if(alpha < 255)
-		to_chat(src, "<span class='warning'>You seem to already be blending in, silly!</span>")
+		var/dunnit = FALSE
+		for(var/datum/modifier/M in modifiers)
+			if(M.type == /datum/modifier/blend_in)
+				var/datum/modifier/blend_in/B = M
+				B.expire()
+				dunnit = TRUE
+		if(!dunnit)
+			to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
 		return
 
 	last_special = world.time + 5 SECONDS	//Please do not spam ty ilu

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1365,9 +1365,20 @@
 	set category = "Abilities"
 	set desc = "Grab a target with any of your appendages!"
 
-	if(stat || paralysis || weakened || stunned || world.time < last_special) //No tongue flicking while stunned.
+	if(stat || paralysis || weakened || stunned) //No tongue flicking while stunned.
 		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
 		return
+
+	var/datum/modifier/blend_in/B	//RS ADD START - Allow long vore trait to be used with chameleon blend in trait!
+	if(world.time < last_special)
+		var/dunnit = FALSE
+		for(var/datum/modifier/M in modifiers)
+			if(M.type == /datum/modifier/blend_in)
+				B = M
+				dunnit = TRUE
+		if(!dunnit)
+			to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
+			return	//RS ADD END
 
 	last_special = world.time + 10 //Anti-spam.
 
@@ -1423,9 +1434,8 @@
 		var/obj/item/projectile/beam/appendage/appendage_attack = new /obj/item/projectile/beam/appendage(get_turf(loc))
 		appendage_attack.launch_projectile(target, BP_TORSO, src) //Send it.
 		last_special = world.time + 100 //Cooldown for successful strike.
-
-
-
+		if(B)	//RS ADD
+			B.expire()	//RS ADD
 
 /obj/item/projectile/beam/appendage //The tongue projecitle.
 	name = "appendage"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -369,3 +369,14 @@
 /datum/trait/positive/wall_climber_pro/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	S.can_climb = TRUE
+
+/datum/trait/positive/blend_in	//RS ADD START
+	name = "Chameleon Blend In"
+	desc = "Allows one to blend in to their environment while immobile, becoming very difficult to see!"
+	cost = 1
+	custom_only = TRUE
+
+/datum/trait/positive/blend_in/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/proc/chameleon_blend
+	//RS ADD END

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -13,6 +13,7 @@
 		to_world_log("## DEBUG: apply_damage() was called on [src], with [damage] damage, and an armor value of [blocked].")
 	if(!damage || (blocked >= 100))
 		return 0
+	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 	for(var/datum/modifier/M in modifiers) //MODIFIER STUFF. It's best to do this RIGHT before armor is calculated, so it's done here! This is the 'forcefield' defence.
 		if(damagetype == BRUTE && (!isnull(M.effective_brute_resistance)))
 			if(M.energy_based)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -189,8 +189,8 @@
 //'include_robo' only applies to healing, for legacy purposes, as all damage typically hurts both types of organs
 /mob/living/proc/adjustBruteLoss(var/amount,var/include_robo)
 	if(status_flags & GODMODE)	return 0	//godmode
-
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -222,6 +222,7 @@
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -250,6 +251,7 @@
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -284,6 +286,7 @@
 /mob/living/proc/adjustFireLoss(var/amount,var/include_robo)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -313,6 +316,7 @@
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.incoming_damage_percent))
 				if(M.energy_based)
@@ -339,6 +343,9 @@
 
 /mob/living/proc/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
+	if(amount > 0)	//RS ADD
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
+
 	brainloss = min(max(brainloss + amount, 0),(getMaxHealth()*2))
 
 /mob/living/proc/setBrainLoss(var/amount)
@@ -351,6 +358,7 @@
 /mob/living/proc/adjustHalLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(M.energy_based && (!isnull(M.incoming_hal_damage_percent) || !isnull(M.disable_duration_percent)))
 				M.energy_source.use(M.damage_cost*amount) // Cost of the Damage absorbed.
@@ -415,6 +423,7 @@
 
 /mob/living/AdjustStunned(amount)
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.disable_duration_percent))
 				amount = round(amount * M.disable_duration_percent)
@@ -441,6 +450,7 @@
 
 /mob/living/AdjustWeakened(amount)
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.disable_duration_percent))
 				amount = round(amount * M.disable_duration_percent)
@@ -467,6 +477,7 @@
 
 /mob/living/AdjustParalysis(amount)
 	if(amount > 0)
+		SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE)	//RS ADD
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.disable_duration_percent))
 				amount = round(amount * M.disable_duration_percent)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
@@ -419,12 +419,14 @@
 	if(ishuman(AM))
 		var/mob/living/carbon/human/L = AM
 		L.fur_submerge()
+		L.plane = -26	//RS ADD
 
 /turf/simulated/floor/outdoors/fur/Exited(atom/movable/AM, atom/new_loc)
 	. = ..()
 	if(ishuman(AM))
 		var/mob/living/carbon/human/L = AM
 		L.fur_submerge()
+		L.plane = initial(L.plane)	//RS ADD
 
 /mob/living/carbon/human/proc/fur_submerge()
 	if(QDESTROYING(src))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -361,6 +361,7 @@
 	user.setMoveCooldown(shoot_time) //no moving while shooting either
 
 	next_fire_time = world.time + shoot_time
+	SEND_SIGNAL(user,COMSIG_MOB_FIRED_GUN)	//RS ADD
 
 	var/held_twohanded = (user.can_wield_item(src) && src.is_held_twohanded(user))
 

--- a/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
+++ b/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
@@ -102,6 +102,7 @@
 	playsound(src, 'sound/weapons/wave.ogg', 60, 1)
 
 	user.visible_message("<span class='warning'>[user] fires \the [src]!</span>","<span class='warning'>You fire \the [src]!</span>")
+	SEND_SIGNAL(user,COMSIG_MOB_FIRED_GUN)	//RS ADD
 
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(4, 1, A)

--- a/code/modules/xenobio/items/weapons_vr.dm
+++ b/code/modules/xenobio/items/weapons_vr.dm
@@ -55,6 +55,7 @@
 	playsound(src, 'sound/weapons/wave.ogg', 60, 1)
 
 	user.visible_message("<span class='warning'>[user] fires \the [src]!</span>","<span class='warning'>You fire \the [src]!</span>")
+	SEND_SIGNAL(user,COMSIG_MOB_FIRED_GUN)	//RS ADD
 
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(4, 1, A)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3011,6 +3011,7 @@
 #include "code\modules\mob\living\carbon\human\species\station\prommie_blob.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station_special_abilities_vr.dm"
+#include "code\modules\mob\living\carbon\human\species\station\station_special_abilities_rs.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station_special_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\teshari.dm"


### PR DESCRIPTION
Adds a positive trait for custom species to take, that allows for the use of the 'Blend In' verb!

Blend in allows one to blend in with their surroundings and to become almost undetectable by sight while the user is standing still! It takes a few seconds for the ability to fully take effect, though the time it takes to disappear visually will be faster in darker environments!

This ability will be interrupted if the user moves, is moved, or takes any damage! It will also be interrupted if the user attacks, or fires a weapon!

While blended in, the user will not attract the attention of any hostile NPCs that identify targets by sight, though, there is a period of a few seconds after using the ability where the mobs will still notice you even if you have fully blended in, so it is best used before an NPC has noticed you, or otherwise with ample space between yourself and the enemy that they might lose track of you. Most hostile NPCs will still know where to look for long enough to come over and hit you if you use it where they can see you.

Compatibility was added with long predatorial reach, so that it can be used while blended in! Doing this will reveal you, but not before the attack has been carried out!

I hope all of this will make your sneaky chameleon dreams come true!!! Have fun~