### PR TITLE
Fix Bluespace Harpoon Tummy Sprite Bug

### DIFF
--- a/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
+++ b/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
@@ -162,6 +162,7 @@
 							living_user.forceMove(belly_dest)
 							to_chat(pred, "<span class='notice'>[living_user] materializes inside you as they end up in your [belly_dest]!</span>")
 							to_chat(living_user, "<span class='danger'>You materialize inside [pred] as you end up in their [belly_dest]!</span>")
+							pred.update_icon() //RS Add: Fixes bug where tum was not updating (Lira, May 2025)
 
 	else
 		for(var/obj/O in FromTurf)


### PR DESCRIPTION
Makes it so if you spont vore into a mob with a bluespace harpoon, the tummy sprite updates.  

Resolves: https://github.com/TS-Rogue-Star/Rogue-Star/issues/298