### PR TITLE
Leopardmander and Big Dragon Adjustments

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -47,6 +47,7 @@ I think I covered everything.
 ///
 ///		Main type
 ///
+/mob/living/var/natural_healer = FALSE	//RS ADD - If true, healbelly costs 0 nutrition to use
 
 /mob/living/simple_mob/vore/bigdragon
 	name = "large dragon"
@@ -111,6 +112,7 @@ I think I covered everything.
 	plane = ABOVE_MOB_PLANE
 
 	load_owner = "seriouslydontsavethis"	//RS - ADD - They're essentially boss mobs, so, yeah, just don't.
+	natural_healer = TRUE	//RS ADD
 
 	//Dragon vars
 	var/notame
@@ -254,7 +256,7 @@ I think I covered everything.
 
 /mob/living/simple_mob/vore/bigdragon/Initialize()
 	..()
-	src.adjust_nutrition(src.max_nutrition)
+//	src.adjust_nutrition(src.max_nutrition)	//RS EDIT
 	build_icons(1)
 	add_language(LANGUAGE_DRUDAKAR)
 	add_language(LANGUAGE_UNATHI)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
@@ -49,6 +49,7 @@
 	max_tox = 0 // for virgo3b survivability
 
 	nom_mob = TRUE
+	natural_healer = TRUE //RS ADD
 
 /datum/category_item/catalogue/fauna/leopardmander
 	name = "Sivian Fauna - Va'aen Drake"
@@ -72,7 +73,7 @@
 
 /mob/living/simple_mob/vore/leopardmander/Initialize()
 	..()
-	src.adjust_nutrition(src.max_nutrition)
+//	src.adjust_nutrition(src.max_nutrition) //RS EDIT
 
 /mob/living/simple_mob/vore/leopardmander/init_vore()
 	. = ..()
@@ -101,6 +102,7 @@
 		"As the thinning air begins to make you feel dizzy, menacing bworps and grumbles fill that dark, constantly shifting organ!",
 		"The constant, rhythmic kneading and massaging starts to take its toll along with the muggy heat, making you feel weaker and weaker!",
 		"The drake happily wanders around while digesting its meal, almost like it is trying to show off the hanging gut you've given it. Not like it made much of a difference on his already borderline obese form anyway~")
+	B.human_prey_swallow_time = 40	//RS ADD - It's healing you make it happen FASTER AAAAAA
 
 /datum/say_list/leopardmander
 	speak = list("Prurr.", "Rrrhf.", "Rrrrrll.", "Mrrrrph.")


### PR DESCRIPTION
Leopardmander and Big Dragon have started with max nutrition, which before we multipled the max nutrition was fine, but now that the max nutrition is 50,000, they incidentally are really OP on power creation with the REGs.

These mobs had max nutrition however because of their use of healbelly, and healbelly consumes nutrition.

To make sure this is not compromised, slightly refactored how healbelly works, so that it won't consume nutrition from the mob if it has the natural_healer flag. This way these mobs can heal anyone as much as they want, and their nutrition will never be a factor.

Along with this, I decreased the leopardmander's human swallowing time to be in line with that of the bigdragon's healing process. It took so long that I thought it was broken, so, I made it so that it can swallow you before the weaken ends, which feels more correct.