### PR TITLE
Borgs can't look at machines

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -199,11 +199,11 @@
 	desc = "Looking into the distance!"
 
 	stacks = MODIFIER_STACK_EXTEND
-	var/obj/effect/look_spoiler/our_eye
+	var/obj/effect/abstract/look_spoiler/our_eye
 
 /datum/modifier/look_over_there/New(var/new_holder, var/new_origin)
 	. = ..()
-	our_eye = new /obj/effect/look_spoiler(get_turf(holder))
+	our_eye = new /obj/effect/abstract/look_spoiler(get_turf(holder))
 
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(expire))
 	RegisterSignal(holder, COMSIG_MOB_APPLY_DAMGE, PROC_REF(expire))
@@ -235,7 +235,7 @@
 	animate(holder.client,0.75 SECOND,FALSE,SINE_EASING,pixel_x = to_x,pixel_y = to_y)
 	holder.face_atom(T)	//Woah look!
 
-/obj/effect/look_spoiler
+/obj/effect/abstract/look_spoiler
 	name = "specter"
 	icon = 'icons/rogue-star/misc96x96.dmi'
 	icon_state = "look_spoiler"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -180,6 +180,9 @@
 		return
 	if(isAI(src))	//AI vision is already super funky, so, let's just not
 		return
+	if(isrobot(src))
+		if(istype(A,/obj/machinery))	//Let's just assume that if we're clicking a machine as a borg then we probably don't want to look!
+			return
 	var/turf/T = get_turf(A)
 	if(get_dist(get_turf(src),T) > world.view)	//You can only look to the edge of your normal vision!
 		return

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -152,6 +152,8 @@
 	if(istype(AM, /obj/effect/plant))
 		return
 	//VOREStation Addition End
+	if(istype(AM, /obj/effect/abstract/look_spoiler))	//RS ADD
+		return	//RS ADD
 	if(isobserver(AM)) // Ghosts have their own methods for going up and down
 		return
 	if(AM.pulledby) // Animating the movement of pulled things is handled when the puller goes up the stairs
@@ -205,6 +207,8 @@
 	if(istype(AM, /obj/effect/plant))
 		return
 	//VOREStation Addition End
+	if(istype(AM, /obj/effect/abstract/look_spoiler))	//RS ADD
+		return	//RS ADD
 	if(isliving(AM))
 		var/mob/living/L = AM
 
@@ -410,6 +414,8 @@
 	if(istype(AM, /obj/effect/plant))
 		return
 	//VOREStation Addition End
+	if(istype(AM, /obj/effect/abstract/look_spoiler))	//RS ADD
+		return	//RS ADD
 	if(isobserver(AM)) // Ghosts have their own methods for going up and down
 		return
 	if(AM.pulledby) // Animating the movement of pulled things is handled when the puller goes up the stairs
@@ -461,6 +467,8 @@
 	if(istype(AM, /obj/effect/plant))
 		return
 	//VOREStation Addition End
+	if(istype(AM, /obj/effect/abstract/look_spoiler))	//RS ADD
+		return	//RS ADD
 	if(isliving(AM))
 		var/mob/living/L = AM
 		if(L.grabbed_by.len) // Same as pulledby, whoever's holding you will keep you from going down stairs.

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -111,6 +111,8 @@
 	spawn(1)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
 		var/items_moved = 0
 		for(var/atom/movable/A in affecting)
+			if(istype(A,/obj/effect))	//RS ADD - Don't move effects, they are not usually strictly physical things
+				continue				//RS ADD
 			if(!A.anchored)
 				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
 					step(A,movedir)


### PR DESCRIPTION
Makes it so that if borgs alt+click on a machine, then the look function won't fire. Borgs have existing alt+click functionality with a lot of machines, and how that's handled isn't the same across them. SO! Rather than adding custom handling for each of these, I think it's best to simply block the look function on machines for borgs!!!