### PR TITLE
don't spawn as mobs where people are looking

### DIFF
--- a/code/modules/mob/ghost_simplemob_spawn.dm
+++ b/code/modules/mob/ghost_simplemob_spawn.dm
@@ -164,6 +164,9 @@ GLOBAL_LIST_INIT(ghost_spawnable_mobs,list(
 		if(sus.ckey)
 			to_chat(src, "<span class='danger'>\The [sus] can see you here, try somewhere more discreet!</span>")
 			return
+	for(var/atom/movable/look_spoiler/eye in view(world.view,ourturf))	//RS ADD START - Also don't spawn where people are looking, this covers cameras now too!
+		to_chat(src, "<span class='danger'>[eye] is looking here. Try somewhere else!</span>")
+		return	//RS ADD START
 
 	var/mob/living/simple_mob/newPred = new mobtype(ourturf)
 	qdel(newPred.ai_holder)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_rs.dm
@@ -204,6 +204,7 @@
 /datum/modifier/look_over_there/New(var/new_holder, var/new_origin)
 	. = ..()
 	our_eye = new /atom/movable/look_spoiler(get_turf(holder))
+	our_eye.name = holder
 
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(expire))
 	RegisterSignal(holder, COMSIG_MOB_APPLY_DAMGE, PROC_REF(expire))


### PR DESCRIPTION
updates the 'Join as mob' verb to account for the new look function and immersion.

This should make it less likely that someone will randomly spawn a mob where a player is looking, even if that place would ordinarily be outside of that person's view range.

This solution also covers camera views to some extent, though cameras can sometimes see further than normal view range, so it's not a perfect solution! But! if someone is looking at where you want to spawn through a camera, you will probably not be able to spawn there