### PR TITLE
Fixes nutrition examine message thresholds.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -50,9 +50,9 @@
 			message = nutrition_messages[7]
 		if(7800 to 10399) // Three people.
 			message = nutrition_messages[8]
-		if(10400 to 12999) // Four people.
+		if(10400 to 18199) // Four people.
 			message = nutrition_messages[9]
-		if(13000 to INFINITY) // More. RS EDIT END
+		if(18200 to INFINITY) // More. RS EDIT END
 			message = nutrition_messages[10]
 	if(message)
 		message = "<span class='notice'>[message]</span>"


### PR DESCRIPTION
Every threshold above 3 was way too high for what it was supposed to be according to the comments, and below 3 was way too low to the point of contradicting the game mechanics. Fixes #977