### PR TITLE
damage overlay

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -23,6 +23,7 @@
 #define DM_FLAG_FORCEPSAY		0x40
 #define DM_FLAG_SLOWBODY		0x80  //RS Edit || Ports CHOMPStation Pr 5161
 #define DM_FLAG_SLOWBRUTAL		0x100 //RS Edit
+#define DM_FLAG_DAMAGEICON		0x200 //RS ADD
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -348,6 +348,12 @@ var/list/_client_preferences_by_type
 	enabled_description = "Enabled"
 	disabled_description = "Disabled"
 
+/datum/client_preference/vore_damage_overlay
+	description = "Vore Self Damage Overlay"
+	key = "VORE_DAMAGE_OVERLAY"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+
 //RS ADDITION END
 
 /datum/client_preference/runechat_mob

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -196,7 +196,10 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	if(isbelly(loc))	//RS ADD START
 		var/obj/belly/b = loc
 		if(!(b.mode_flags & DM_FLAG_DAMAGEICON))
-			return		//RS ADD END
+			return
+		if(client)
+			if(!client.is_preference_enabled(/datum/client_preference/vore_damage_overlay))
+				return		//RS ADD END
 
 	// first check whether something actually changed about damage appearance
 	var/damage_appearance = ""

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -193,6 +193,11 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 	remove_layer(MOB_DAM_LAYER)
 
+	if(isbelly(loc))	//RS ADD START
+		var/obj/belly/b = loc
+		if(!(b.mode_flags & DM_FLAG_DAMAGEICON))
+			return		//RS ADD END
+
 	// first check whether something actually changed about damage appearance
 	var/damage_appearance = ""
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -88,7 +88,7 @@
 	//drain modes // RS Edit: Ports VOREStation PR15876
 	var/tmp/static/list/drainmodes = list(DR_NORMAL,DR_SLEEP,DR_FAKE,DR_WEIGHT)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Gradual Body Digestion" = DM_FLAG_SLOWBRUTAL, "Apply Damage Icons" = DM_FLAG_DAMAGEICON)	//RS EDIT
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Gradual Body Digestion" = DM_FLAG_SLOWBRUTAL, "Visual Damage" = DM_FLAG_DAMAGEICON)	//RS EDIT
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST)
 
@@ -850,6 +850,10 @@
 	//Clean up our own business
 	if(!ishuman(owner))
 		owner.update_icons()
+
+	if(ishuman(M))	//RS ADD START - Let's make sure people's damage overlays happen when they are released
+		var/mob/living/carbon/human/H = M
+		H.UpdateDamageIcon()	//RS ADD END
 
 	//Determines privacy
 	var/privacy_range = world.view

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -88,7 +88,7 @@
 	//drain modes // RS Edit: Ports VOREStation PR15876
 	var/tmp/static/list/drainmodes = list(DR_NORMAL,DR_SLEEP,DR_FAKE,DR_WEIGHT)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Gradual Body Digestion" = DM_FLAG_SLOWBRUTAL)
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Gradual Body Digestion" = DM_FLAG_SLOWBRUTAL, "Apply Damage Icons" = DM_FLAG_DAMAGEICON)	//RS EDIT
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST)
 


### PR DESCRIPTION
Adds "Apply Damage Icons" addon option to bellies.

In RSUI, the icon displayed for the prey is the actual vis contents, which includes the damage overlay!

Now I have made it so that when considering adding the damage overlay while in a belly, it checks to see if that belly has this addon included before doing so. This means that, if they enter a hold belly with damage icons, they will probably keep them until something updates the damage overlay again! So, this mostly just affects digest mode and heal mode, as both of those will trigger it!

It should be noted that this affects the actual icon, not the vore panel icon. The vore panel icon doesn't update over time, so this won't change anything with that.

Also adds the "Vore Self Damage Overlay" preference. This starts enabled. When disabled, while in a belly damage overlays will not apply to your character's sprite. This is a global preference!