### PR TITLE
Cleans empty newlines from circuit assembly examine text

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -213,7 +213,10 @@
 	. = ..()
 	if(Adjacent(user))
 		for(var/obj/item/integrated_circuit/IC in contents)
-			. += IC.external_examine(user)
+			// Make sure there's actually examine text to prevent empty lines being printed for EVERY component!
+			var/examine_text = IC.external_examine(user)
+			if (length(examine_text))
+				. += examine_text
 		if(opened)
 			tgui_interact(user)
 


### PR DESCRIPTION
Essentially a port of my Virgo PR, https://github.com/VOREStation/VOREStation/pull/18087 .

Before, whenever you examined a circuit assembly, it would print a new line for every single component in the assembly - EVEN if the component in question had nothing to show. This results in component-heavy builds spamming tons of empty newlines when they have nothing to show. Whoops!
This (hopefully) fixes that.