### PR TITLE
Fix shuttle init debug message

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -63,7 +63,7 @@
 	if(!istype(current_location))
 		if(debug_logging)
 			log_shuttle("UM whoops, no initial? [src]")
-		CRASH("Shuttle '[name]' could not find its starting location landmark [current_location].")
+		CRASH("Shuttle '[name]' could not find its starting location landmark [initial(current_location)].") // RS Edit - Fix debug message (SSshuttles will have nulled this if it couldn't find it)
 
 	if(src.name in SSshuttles.shuttles)
 		CRASH("A shuttle with the name '[name]' is already defined.")


### PR DESCRIPTION
SSshuttles.get_landmark(initial_landmark) may return null and clear the initial value of this variable, depriving us of actually seeing anything in the message. Get the initial value and display that, instead.