### PR TITLE
Global Proc Call Fix

### DIFF
--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -340,7 +340,7 @@ GLOBAL_LIST_EMPTY(bicon_cache) // Cache of the <img> tag results, not the icons
 		base64 = icon2base64(A.examine_icon(), key)
 		GLOB.bicon_cache[key] = base64
 		if(changes_often)
-			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(expire_bicon_cache), key), 50 SECONDS, TIMER_UNIQUE)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(expire_bicon_cache), key), 50 SECONDS, TIMER_UNIQUE) //RS Edit: Global Proc so needs global ref (Lira, August 2025)
 
 	// May add a class to the img tag created by bicon
 	if(use_class)


### PR DESCRIPTION
Fixes a bad proc call that was triggering runtimes by appropriately setting it to global.