### PR TITLE
Vore Death Notification Timer Update

### DIFF
--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -69,14 +69,14 @@
 	if(db)
 		var/datum/transhuman/mind_record/record = db.backed_up[src.mind.name]
 		if(!(record.dead_state == MR_DEAD))
-			if((world.time - timeofdeath ) > 5 MINUTES)	//Allows notify transcore to be used if you have an entry but for some reason weren't marked as dead
-				record.dead_state = MR_DEAD				//Such as if you got scanned but didn't take an implant. It's a little funky, but I mean, you got scanned
-				db.notify(record)						//So you probably will want to let someone know if you die.
-				record.last_notification = world.time
+			if(mind.vore_death || (world.time - timeofdeath ) > 5 MINUTES)	//RS Edit: Allow immediate notifications with a vore death, consistent with autosleever behavior (Lira, August 2025)
+				record.dead_state = MR_DEAD									//Allows notify transcore to be used if you have an entry but for some reason weren't marked as dead
+				db.notify(record)											//Such as if you got scanned but didn't take an implant. It's a little funky, but I mean, you got scanned
+				record.last_notification = world.time						//So you probably will want to let someone know if you die.
 				to_chat(src, "<span class='notice'>New notification has been sent.</span>")
 			else
 				to_chat(src, "<span class='warning'>Your backup is not past-due yet.</span>")
-		else if((world.time - record.last_notification) < 5 MINUTES)
+		else if((world.time - record.last_notification) < 5 MINUTES && !(mind.vore_death && isnull(record.last_notification)))  //RS Edit: Allow immediate notifications with a vore death, consistent with autosleever behavior (Lira, August 2025)
 			to_chat(src, "<span class='warning'>Too little time has passed since your last notification.</span>")
 		else
 			db.notify(record)


### PR DESCRIPTION
Updates the time until the transcore notification button can be used for a ghost to 0 for vore deaths.  This makes the behavior consistent with the autosleever, since there was really no reason for the autosleever to be the faster option.