### PR TITLE
Hunting tweak

### DIFF
--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -67,7 +67,7 @@
 		M.faction = mob_faction
 
 	if(mob_disable_hunting)	//RS ADD
-		M.hunting = FALSE	//RS ADD
+		M.hunter = FALSE	//RS ADD
 
 
 /obj/random/mob/sif

--- a/code/game/objects/random/mob.dm
+++ b/code/game/objects/random/mob.dm
@@ -16,6 +16,7 @@
 	var/mob_wander_distance = 3
 	var/mob_hostile = 0
 	var/mob_retaliate = 0
+	var/mob_disable_hunting = TRUE	//RS ADD - If true, mobs spawned through the random spawners will have hunter set to FALSE
 
 /obj/random/mob/item_to_spawn()
 	return pick(prob(10);/mob/living/simple_mob/animal/passive/lizard,
@@ -65,6 +66,8 @@
 	if(mob_faction)
 		M.faction = mob_faction
 
+	if(mob_disable_hunting)	//RS ADD
+		M.hunting = FALSE	//RS ADD
 
 
 /obj/random/mob/sif

--- a/code/modules/mob/living/simple_mob/donteatpets_vr.dm
+++ b/code/modules/mob/living/simple_mob/donteatpets_vr.dm
@@ -4,34 +4,41 @@
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/dog/corgi/Lisa
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/dog/corgi/puppy
 	digestable = 0
 	devourable = 0
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/cat/runtime
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/cat/kitten
 	digestable = 0
 	devourable = 0
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/bird/parrot/poly
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/opossum/poppy
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/carbon/human/monkey/punpun
 	digestable = 0
@@ -41,31 +48,38 @@
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/mouse/white/apple //She's a mouse living with a snake. Accidents happen. But don't gurg apple >:I
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/fox/renault
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/crab/Coffee
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/sif/fluffy
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/slime/xenobio/rainbow/kendrick
 	digestable = 0
 	devourable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/chick
 	digestable = 0
 	devourable = 0
+	hunter = FALSE	//RS ADD

--- a/code/modules/mob/living/simple_mob/sd_pets.dm
+++ b/code/modules/mob/living/simple_mob/sd_pets.dm
@@ -4,6 +4,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /datum/category_item/catalogue/fauna/catslug/tulidaan
 	name = "Alien Wildlife - Catslug - Tulidaan"
@@ -31,6 +32,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/tulidaan)
 	holder_type = /obj/item/weapon/holder/catslug/tulidaan
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /obj/item/weapon/holder/catslug/tulidaan
 	item_state = "tulidaan"
@@ -40,6 +42,7 @@
 	desc = "Don't make fun, they have a condition."
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/mouse/jerboa/leggy/New()
 	..()
@@ -51,6 +54,7 @@
 	desc = "Heading out west wasn't far enough, so he's going to space!"
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/mouse/brown/feivel/New()
 	..()
@@ -64,6 +68,7 @@
 	digestable = 0
 	holder_type = /obj/item/weapon/holder/cat/jones
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /obj/item/weapon/holder/cat/jones
 	item_state = "cat2"
@@ -74,6 +79,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/tindalos/twigs
 	name = "Twigs"
@@ -81,6 +87,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/bird/azure_tit/iceman
 	name = "Iceman"
@@ -88,6 +95,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/animal/passive/mimepet/gregory
 	name = "Gregory XXVI Esq."
@@ -95,6 +103,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /mob/living/simple_mob/vore/fennec/bridgette
 	name = "Bridgette"
@@ -102,6 +111,7 @@
 	devourable = 0
 	digestable = 0
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 /datum/category_item/catalogue/fauna/otie/cocoa
 	name = "Creature - Otie - Cocoa"
@@ -124,6 +134,7 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive/otie/cocoa
 	catalogue_data = list(/datum/category_item/catalogue/fauna/otie/cocoa)
 	load_owner = "STATION"
+	hunter = FALSE	//RS ADD
 
 
 /datum/ai_holder/simple_mob/melee/evasive/otie/cocoa


### PR DESCRIPTION
Makes the various station pets (not from the pet system) not hunt!

Also makes it so semirandom mob spawners disable hunting by default.