### PR TITLE
Flask Update

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -171,7 +171,7 @@ GLOBAL_DATUM_INIT(gear_tweak_free_matrix_recolor, /datum/gear_tweak/matrix_recol
 	return "Random"
 
 /datum/gear_tweak/reagents/get_metadata(var/user, var/list/metadata)
-	. = tgui_input_list(user, "Choose an entry.", "Character Preference", valid_reagents + list("Random", "None"), metadata)
+	. = tgui_input_list(user, "Choose an entry.", "Character Preference", valid_reagents + list("Random", "Random Alcoholic", "Random Non-Alcoholic", "None"), metadata) //RS Edit: Add random alcoholic and random non-alcoholic options (Lira, September 2025)
 	if(!.)
 		return metadata
 
@@ -180,6 +180,12 @@ GLOBAL_DATUM_INIT(gear_tweak_free_matrix_recolor, /datum/gear_tweak/matrix_recol
 		return
 	if(metadata == "Random")
 		. = valid_reagents[pick(valid_reagents)]
+	else if(metadata == "Random Alcoholic") //RS Add: Random alcoholic drink (Lira, September 2025)
+		var/list/alcohols = lunchables_ethanol_reagents()
+		. = alcohols[pick(alcohols)]
+	else if(metadata == "Random Non-Alcoholic") //RS Add: Random non-alcoholic drink (Lira, September 2025)
+		var/list/softs = lunchables_drink_reagents()
+		. = softs[pick(softs)]
 	else
 		. = valid_reagents[metadata]
 	I.reagents.add_reagent(., I.reagents.get_free_space())

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -98,7 +98,17 @@
 
 /datum/gear/flask/New()
 	..()
-	gear_tweaks += new/datum/gear_tweak/reagents(lunchables_drink_reagents()) //RS Edit: Allow non-alcoholic drinks (Lira, August 2025)
+	//RS Add: Build a combined drink list (Lira, September 2025)
+	var/list/_drinks = lunchables_drink_reagents()
+	_drinks = _drinks.Copy()
+	var/list/_booze = lunchables_ethanol_reagents()
+	for(var/k in _booze)
+		if(_drinks[k])
+			_drinks["[k] (alcoholic)"] = _booze[k]
+		else
+			_drinks[k] = _booze[k]
+	//RS Add End
+	gear_tweaks += new/datum/gear_tweak/reagents(_drinks) //RS Edit: Use consolidated drink list (Lira, September 2025)
 
 /datum/gear/vacflask
 	display_name = "vacuum-flask"
@@ -106,7 +116,17 @@
 
 /datum/gear/vacflask/New()
 	..()
-	gear_tweaks += new/datum/gear_tweak/reagents(lunchables_drink_reagents())
+	//RS Add: Build a combined drink list (Lira, September 2025)
+	var/list/_drinks = lunchables_drink_reagents()
+	_drinks = _drinks.Copy()
+	var/list/_booze = lunchables_ethanol_reagents()
+	for(var/k in _booze)
+		if(_drinks[k])
+			_drinks["[k] (alcoholic)"] = _booze[k]
+		else
+			_drinks[k] = _booze[k]
+	//RS Add End
+	gear_tweaks += new/datum/gear_tweak/reagents(_drinks) //RS Edit: Use consolidated drink list (Lira, September 2025)
 
 /datum/gear/lunchbox
 	display_name = "lunchbox"
@@ -195,4 +215,14 @@
 	coffeemugs["tall rainbow coffee mug"] = /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeemug/tall/rainbow
 	coffeemugs["Talon coffee mug"] = /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeemug/talon
 	gear_tweaks += new /datum/gear_tweak/path(coffeemugs)
-	gear_tweaks += new /datum/gear_tweak/reagents(lunchables_drink_reagents())
+	//RS Add: Build a combined drink list (Lira, September 2025)
+	var/list/_drinks = lunchables_drink_reagents()
+	_drinks = _drinks.Copy()
+	var/list/_booze = lunchables_ethanol_reagents()
+	for(var/k in _booze)
+		if(_drinks[k])
+			_drinks["[k] (alcoholic)"] = _booze[k]
+		else
+			_drinks[k] = _booze[k]
+	//RS Add End
+	gear_tweaks += new /datum/gear_tweak/reagents(_drinks)  //RS Edit: Use consolidated drink list (Lira, September 2025)


### PR DESCRIPTION
Allow non-alcoholic drinks in the flask in character loadout.  Makes it consistent with the mug and vacuum flask drink options.

Updated to create new random options, allowing either random alcoholic or random non-alcoholic drinks to be chosen for the flask, vacuum-flask and mug.  All three allow all alcoholic and non-alcoholic drinks now.