### PR TITLE
mob tweaks

### DIFF
--- a/code/modules/ai/ai_holder_movement.dm
+++ b/code/modules/ai/ai_holder_movement.dm
@@ -38,6 +38,8 @@
 		give_up_movement()
 		set_stance(stance == STANCE_REPOSITION ? STANCE_APPROACH : STANCE_IDLE)
 		ai_log("walk_to_destination() : Destination reached. Exiting.", AI_LOG_INFO)
+		if(holder.hunter)	//RS ADD
+			blood_hunt()	//RS ADD
 		return
 
 	ai_log("walk_to_destination() : Walking.", AI_LOG_TRACE)

--- a/code/modules/mob/living/simple_mob/simple_mob_rs.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_rs.dm
@@ -97,9 +97,16 @@
 	if(idle_time >= 30)
 		expire()
 
-var/mob/living/simple_mob/simplemob_bleeds = TRUE
+/mob/living/simple_mob/
+	var/simplemob_bleeds = TRUE
+
+/mob/living/simple_mob/xeno
+	simplemob_bleeds = FALSE
+	hunter = FALSE
+/mob/living/simple_mob/mechanical
+	simplemob_bleeds = FALSE
 
 /mob/living/simple_mob/adjustBruteLoss(amount, include_robo)
 	. = ..()
-	if(simplemob_bleeds)
+	if(amount > 0 && simplemob_bleeds)
 		add_modifier(/datum/modifier/bleeding)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -575,23 +575,22 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	return 1
 
 /mob/living/can_eat(var/food)	//RS ADD START
-	if(hunter)
-		if(isobj(food))
-			switch(food_pref)
-				if(OMNIVORE)
-					if(istype(food,/obj/item/weapon/reagent_containers/food/snacks))
-						return TRUE
-					if(istype(food,/obj/effect/decal/cleanable/blood))
-						return TRUE
-				if(CARNIVORE)
-					if(istype(food,/obj/item/weapon/reagent_containers/food/snacks/meat))
-						return TRUE
-					if(istype(food,/obj/effect/decal/cleanable/blood))
-						return TRUE
-				if(HERBIVORE)
-					if(istype(food,/obj/item/weapon/reagent_containers/food/snacks/grown))
-						return TRUE
-			return FALSE
+	if(isobj(food))
+		switch(food_pref)
+			if(OMNIVORE)
+				if(istype(food,/obj/item/weapon/reagent_containers/food/snacks))
+					return TRUE
+				if(istype(food,/obj/effect/decal/cleanable/blood))
+					return TRUE
+			if(CARNIVORE)
+				if(istype(food,/obj/item/weapon/reagent_containers/food/snacks/meat))
+					return TRUE
+				if(istype(food,/obj/effect/decal/cleanable/blood))
+					return TRUE
+			if(HERBIVORE)
+				if(istype(food,/obj/item/weapon/reagent_containers/food/snacks/grown))
+					return TRUE
+		return FALSE
 	return TRUE		//RS ADD END
 
 /mob/proc/can_force_feed()


### PR DESCRIPTION
Makes it so that xenobio slimes and mechanical mobs don't bleed!

Also makes it so that mobs know where you are a little better. They will follow you around corners better, and will engage you at the same diagonal distance as their cardinal distance. In general, mobs will track you much better than before.

Also makes it so that retaliate mobs will stop attacking you if they hadn't been attacked in the last 5 seconds, as long as their health is above 75%, so you can bonk a mob a little and run away without them trying to murder you forever.