### PR TITLE
Added code that lets simple mobs bust through barricades + ranged damage

### DIFF
--- a/code/game/objects/structures/barricades.dm
+++ b/code/game/objects/structures/barricades.dm
@@ -44,18 +44,31 @@
 					visible_message("<span class='notice'>[user] repairs \the [src].</span>")
 				return
 		return
+	//RS remove Sari Bork 9/12/2025 (an else that couldnt be reached due to returns)
+	switch(W.damtype)
+		if("fire")
+			health -= W.force * 1
+		if("brute")
+			health -= W.force * 0.75
+	if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD)))
+		playsound(src, 'sound/effects/woodcutting.ogg', 100, 1)
 	else
-		switch(W.damtype)
-			if("fire")
-				health -= W.force * 1
-			if("brute")
-				health -= W.force * 0.75
-		if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD)))
-			playsound(src, 'sound/effects/woodcutting.ogg', 100, 1)
-		else
-			playsound(src, 'sound/weapons/smash.ogg', 50, 1)
-		CheckHealth()
-		..()
+		playsound(src, 'sound/weapons/smash.ogg', 50, 1)
+	CheckHealth()
+	..()
+
+/obj/structure/barricade/bullet_act(obj/item/projectile/P, def_zone) //RS Add Sari Bork 9/12/2025
+	. = ..()
+	var/barricade_damage = P.get_structure_damage()
+	if(!barricade_damage)
+		return
+	if(barricade_damage > 30)//large projectiles
+		var/base_multiplier = P.damage_type == BURN ? 0.5 : 0.25
+		health -= barricade_damage * base_multiplier
+	else//small projectiles
+		var/base_multiplier = P.damage_type == BURN ? 0.25 : 0.1
+		health -= barricade_damage * base_multiplier
+	CheckHealth()
 
 /obj/structure/barricade/proc/CheckHealth()
 	if(health <= 0)

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -310,7 +310,7 @@
 
 		// Kill common obstacle in the way like tables.
 		var/obj/structure/obstacle = locate(/obj/structure, problem_turf)
-		if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille))
+		if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille) || istype(obstacle, /obj/structure/barricade) || istype(obstacle, /obj/structure/girder)) //Sari Bork RS Add 9/12/2025
 			ai_log("destroy_surroundings() : Attacking generic structure.", AI_LOG_INFO)
 			return melee_attack(obstacle)
 


### PR DESCRIPTION
barricades and their subtypes (barricades) were not on the simple mob breakthrough list, meaning they could never attack them, this was causing sandbags to be the ultimate defense solution as you were untouchable short of getting exploded.
Patched girders into this list too as ranged mobs will shoot you through them, so its weird for melee mobs to not try to hit you through them either.