### PR TITLE
Trait Tweaks

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -3,15 +3,15 @@
 */
 
 var/global/list/hair_accesories_list= list()// Stores /datum/sprite_accessory/hair_accessory indexed by type
-var/global/list/negative_traits = list()	// Negative custom species traits, indexed by path
-var/global/list/neutral_traits = list()		// Neutral custom species traits, indexed by path
-var/global/list/positive_traits = list()	// Positive custom species traits, indexed by path
-var/global/list/everyone_traits_positive = list()	// Neutral traits available to all species, indexed by path
-var/global/list/everyone_traits_neutral = list()	// Neutral traits available to all species, indexed by path
-var/global/list/everyone_traits_negative = list()	// Neutral traits available to all species, indexed by path
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
 var/global/list/active_ghost_pods = list()
+
+// RS ADD START
+var/global/list/positive_traits_map = list() // Positive traits map, indexed by species, then trait path
+var/global/list/neutral_traits_map = list() // Neutral traits map, indexed by species, then trait path
+var/global/list/negative_traits_map = list() // Negative traits map, indexed by species, then trait path
+// RS ADD END
 
 //Global vars for making the overmap_renamer subsystem.
 //Collects all instances by reference of visitable overmap objects of /obj/effect/overmap/visitable like the debris field.
@@ -548,24 +548,31 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 	// Shakey shakey shake
 	sortTim(all_traits, GLOBAL_PROC_REF(cmp_trait_datums_name), associative = TRUE)
 
+	// RS EDIT START
+    // Initialize species based trait maps
+	for(var/species in GLOB.playable_species)
+		positive_traits_map[species] = list()
+		neutral_traits_map[species] = list()
+		negative_traits_map[species] = list()
+
 	// Split 'em up
 	for(var/traitpath in all_traits)
 		var/datum/trait/T = all_traits[traitpath]
-		var/category = T.category
-		switch(category)
-			if(-INFINITY to -0.1)
-				negative_traits[traitpath] = T
-				if(!(T.custom_only))
-					everyone_traits_negative[traitpath] = T
-			if(0)
-				neutral_traits[traitpath] = T
-				if(!(T.custom_only))
-					everyone_traits_neutral[traitpath] = T
-			if(0.1 to INFINITY)
-				positive_traits[traitpath] = T
-				if(!(T.custom_only))
-					everyone_traits_positive[traitpath] = T
 
+		// More complex, but you only have to do this once at init
+		if (T.custom_only)
+			add_trait_to_species(SPECIES_CUSTOM, traitpath, T)
+		else if (LAZYLEN(T.allowed_species))
+			for (var/species in T.allowed_species)
+				add_trait_to_species(species, traitpath, T)
+		else if (LAZYLEN(T.banned_species))
+			for (var/species in GLOB.playable_species)
+				if(!(species in T.banned_species))
+					add_trait_to_species(species, traitpath, T)
+		else
+			for (var/species in GLOB.playable_species)
+				add_trait_to_species(species, traitpath, T)
+	// RS EDIT END
 
 	// Weaver recipe stuff
 	paths = subtypesof(/datum/weaver_recipe/structure)

--- a/code/_helpers/traits_rs.dm
+++ b/code/_helpers/traits_rs.dm
@@ -1,0 +1,9 @@
+/proc/add_trait_to_species(var/datum/species, var/traitpath, var/datum/trait/T)
+	var/category = T.category
+	switch(category)
+		if(-INFINITY to -0.1)
+			negative_traits_map[species][traitpath] = T
+		if(0)
+			neutral_traits_map[species][traitpath] = T
+		if(0.1 to INFINITY)
+			positive_traits_map[species][traitpath] = T

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -239,11 +239,9 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 		pref.gross_meatbag = 1
 		pref.dirty_synth = 0
 
-	var/datum/species/selected_species = GLOB.all_species[pref.species] // RS ADD
-
 	// Clean up positive traits
 	for(var/datum/trait/path as anything in pref.pos_traits)
-		if(!(path in positive_traits_map[selected_species])) // RS EDIT
+		if(!(path in positive_traits_map[pref.species])) // RS EDIT
 			pref.pos_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
@@ -251,7 +249,7 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 			pref.pos_traits -= path
 	//Neutral traits
 	for(var/datum/trait/path as anything in pref.neu_traits)
-		if(!(path in neutral_traits_map[selected_species])) // RS EDIT
+		if(!(path in neutral_traits_map[pref.species])) // RS EDIT
 			pref.neu_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
@@ -259,12 +257,14 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 			pref.neu_traits -= path
 	//Negative traits
 	for(var/datum/trait/path as anything in pref.neg_traits)
-		if(!(path in negative_traits_map[selected_species])) // RS EDIT
+		if(!(path in negative_traits_map[pref.species])) // RS EDIT
 			pref.neg_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
 		if((pref.dirty_synth && !(take_flags & SYNTHETICS)) || (pref.gross_meatbag && !(take_flags & ORGANICS)))
 			pref.neg_traits -= path
+
+	var/datum/species/selected_species = GLOB.all_species[pref.species]
 
 	if(selected_species.selects_bodytype)
 		if (!(pref.custom_base in pref.get_custom_bases_for_species()))

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -239,12 +239,11 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 		pref.gross_meatbag = 1
 		pref.dirty_synth = 0
 
+	var/datum/species/selected_species = GLOB.all_species[pref.species] // RS ADD
+
 	// Clean up positive traits
 	for(var/datum/trait/path as anything in pref.pos_traits)
-		if(!(path in positive_traits))
-			pref.pos_traits -= path
-			continue
-		if(!(pref.species == SPECIES_CUSTOM) && !(path in everyone_traits_positive))
+		if(!(path in positive_traits_map[selected_species])) // RS EDIT
 			pref.pos_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
@@ -252,10 +251,7 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 			pref.pos_traits -= path
 	//Neutral traits
 	for(var/datum/trait/path as anything in pref.neu_traits)
-		if(!(path in neutral_traits))
-			pref.neu_traits -= path
-			continue
-		if(!(pref.species == SPECIES_CUSTOM) && !(path in everyone_traits_neutral))
+		if(!(path in neutral_traits_map[selected_species])) // RS EDIT
 			pref.neu_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
@@ -263,17 +259,13 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 			pref.neu_traits -= path
 	//Negative traits
 	for(var/datum/trait/path as anything in pref.neg_traits)
-		if(!(path in negative_traits))
-			pref.neg_traits -= path
-			continue
-		if(!(pref.species == SPECIES_CUSTOM) && !(path in everyone_traits_negative))
+		if(!(path in negative_traits_map[selected_species])) // RS EDIT
 			pref.neg_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
 		if((pref.dirty_synth && !(take_flags & SYNTHETICS)) || (pref.gross_meatbag && !(take_flags & ORGANICS)))
 			pref.neg_traits -= path
 
-	var/datum/species/selected_species = GLOB.all_species[pref.species]
 	if(selected_species.selects_bodytype)
 		if (!(pref.custom_base in pref.get_custom_bases_for_species()))
 			pref.custom_base = SPECIES_HUMAN
@@ -354,21 +346,21 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 	. += "<a href='?src=\ref[src];add_trait=[POSITIVE_MODE]'>Positive Trait +</a><br>"
 	. += "<ul>"
 	for(var/T in pref.pos_traits)
-		var/datum/trait/trait = positive_traits[T]
+		var/datum/trait/trait = positive_traits_map[pref.species][T] // RS EDIT
 		. += "<li>- <a href='?src=\ref[src];clicked_pos_trait=[T]'>[trait.name] </a> [get_html_for_trait(trait, pref.pos_traits[T])]</li>"	//RS REMOVAL
 	. += "</ul>"
 
 	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait +</a><br>"
 	. += "<ul>"
 	for(var/T in pref.neu_traits)
-		var/datum/trait/trait = neutral_traits[T]
+		var/datum/trait/trait = neutral_traits_map[pref.species][T] // RS EDIT
 		. += "<li>- <a href='?src=\ref[src];clicked_neu_trait=[T]'>[trait.name] </a> [get_html_for_trait(trait, pref.neu_traits[T])]</li>"	//RS REMOVAL
 	. += "</ul>"
 
 	. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait +</a><br>"
 	. += "<ul>"
 	for(var/T in pref.neg_traits)
-		var/datum/trait/trait = negative_traits[T]
+		var/datum/trait/trait = negative_traits_map[pref.species][T] // RS EDIT
 		. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] </a> [get_html_for_trait(trait, pref.neg_traits[T])]</li>"	//RS REMOVAL
 	. += "</ul>"
 
@@ -571,27 +563,17 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 		var/list/picklist
 		var/list/mylist
 		switch(mode)
+			// RS EDIT START
 			if(POSITIVE_MODE)
-				if(pref.species == SPECIES_CUSTOM)
-					picklist = positive_traits.Copy() - pref.pos_traits
-					mylist = pref.pos_traits
-				else
-					picklist = everyone_traits_positive.Copy() - pref.pos_traits
-					mylist = pref.pos_traits
+				picklist = positive_traits_map[pref.species].Copy() - pref.pos_traits
+				mylist = pref.pos_traits
 			if(NEUTRAL_MODE)
-				if(pref.species == SPECIES_CUSTOM)
-					picklist = neutral_traits.Copy() - pref.neu_traits
-					mylist = pref.neu_traits
-				else
-					picklist = everyone_traits_neutral.Copy() - pref.neu_traits
-					mylist = pref.neu_traits
+				picklist = neutral_traits_map[pref.species].Copy() - pref.neu_traits
+				mylist = pref.neu_traits
 			if(NEGATIVE_MODE)
-				if(pref.species == SPECIES_CUSTOM)
-					picklist = negative_traits.Copy() - pref.neg_traits
-					mylist = pref.neg_traits
-				else
-					picklist = everyone_traits_negative.Copy() - pref.neg_traits
-					mylist = pref.neg_traits
+				picklist = negative_traits_map[pref.species].Copy() - pref.neg_traits
+				mylist = pref.neg_traits
+			// RS EDIT END
 			else
 
 		if(isnull(picklist))
@@ -651,11 +633,8 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 				tgui_alert_async(usr, "The trait you've selected can only be taken by synthetic characters!", "Error")
 				return TOPIC_REFRESH
 
-			if(pref.species in instance.banned_species)
-				tgui_alert_async(usr, "The trait you've selected cannot be taken by the species you've chosen!", "Error")
-				return TOPIC_REFRESH
-
-			if( LAZYLEN(instance.allowed_species) && !(pref.species in instance.allowed_species))
+			if(pref.species in instance.banned_species || (LAZYLEN(instance.allowed_species) && !(pref.species in instance.allowed_species))) // RS EDIT
+				// We shouldn't be able to get here anymore, but let's keep it, just in case...
 				tgui_alert_async(usr, "The trait you've selected cannot be taken by the species you've chosen!", "Error")
 				return TOPIC_REFRESH
 

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -562,16 +562,20 @@ var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","go
 		var/mode = text2num(href_list["add_trait"])
 		var/list/picklist
 		var/list/mylist
+		var/list/listtocopy
 		switch(mode)
 			// RS EDIT START
 			if(POSITIVE_MODE)
-				picklist = positive_traits_map[pref.species].Copy() - pref.pos_traits
+				listtocopy = positive_traits_map[pref.species]
+				picklist = listtocopy.Copy() - pref.pos_traits
 				mylist = pref.pos_traits
 			if(NEUTRAL_MODE)
-				picklist = neutral_traits_map[pref.species].Copy() - pref.neu_traits
+				listtocopy =  neutral_traits_map[pref.species]
+				picklist = listtocopy.Copy() - pref.neu_traits
 				mylist = pref.neu_traits
 			if(NEGATIVE_MODE)
-				picklist = negative_traits_map[pref.species].Copy() - pref.neg_traits
+				listtocopy = negative_traits_map[pref.species]
+				picklist = listtocopy.Copy() - pref.neg_traits
 				mylist = pref.neg_traits
 			// RS EDIT END
 			else

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -50,8 +50,9 @@
 			"x" = list("ks", "kss", "ksss")
 		),
 	autohiss_exempt = list(LANGUAGE_UNATHI))
-
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_zaddat)
+	custom_only = FALSE // RS EDIT
+	allowed_species = list(SPECIES_CUSTOM,SPECIES_PROMETHEAN,SPECIES_PROTEAN)  // RS EDIT
 
 /datum/trait/neutral/autohiss_tajaran
 	name = "Autohiss (Tajaran)"
@@ -63,6 +64,8 @@
 		),
 	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI,LANGUAGE_ALAI))
 	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_zaddat)
+	custom_only = FALSE  // RS EDIT
+	allowed_species = list(SPECIES_CUSTOM,SPECIES_PROMETHEAN,SPECIES_PROTEAN)  // RS EDIT
 
 /datum/trait/neutral/autohiss_zaddat
 	name = "Autohiss (Zaddat)"
@@ -81,6 +84,8 @@
 		),
 	autohiss_exempt = list(LANGUAGE_ZADDAT,LANGUAGE_VESPINAE))
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
+	custom_only = FALSE  // RS EDIT
+	allowed_species = list(SPECIES_CUSTOM,SPECIES_PROMETHEAN,SPECIES_PROTEAN)  // RS EDIT
 
 /datum/trait/neutral/bloodsucker
 	name = "Bloodsucker, Obligate"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -155,6 +155,7 @@
 #include "code\_helpers\string_lists.dm"
 #include "code\_helpers\text.dm"
 #include "code\_helpers\time.dm"
+#include "code\_helpers\traits_rs.dm"
 #include "code\_helpers\turfs.dm"
 #include "code\_helpers\type2type.dm"
 #include "code\_helpers\type_processing.dm"


### PR DESCRIPTION
- Allow Proteans and Prometheans to take autohiss traits.
- Refactor traits into species based trait maps:
  - Prevents traits that a species cannot take from appearing in the trait option list in the character creator (i.e. Xenochimera)
  - Reduces specific handling for `CUSTOM_SPECIES` during character sanitization
  - Fixes existing bug that allows users to take traits that their character's species shouldn't have.