### PR TITLE
Fix phased out planetary movement

### DIFF
--- a/code/game/objects/effects/map_effects/portal.dm
+++ b/code/game/objects/effects/map_effects/portal.dm
@@ -71,8 +71,8 @@ when portals are shortly lived, or when portals are made to be obvious with spec
 
 // Called when something touches the portal, and usually teleports them to the other side.
 /obj/effect/map_effect/portal/Crossed(atom/movable/AM)
-	if(AM.is_incorporeal())
-		return
+//	if(AM.is_incorporeal()) // RS Removal why not allow phased out shadekin to go through them???
+//		return
 	..()
 	if(!AM)
 		return


### PR DESCRIPTION
These lines of code are just deliberately making phased out shadekin unable to cross portals (which are used to stitch planet maps together), but why?