### PR TITLE
Hide Head Flag

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -55,6 +55,7 @@
 #define HIDEEARS 0x2 // Headsets and such.
 #define HIDEEYES 0x4 // Glasses.
 #define HIDEFACE 0x8 // Dictates whether we appear as "Unknown".
+#define HIDEHEAD 0x10 // RS Add: Prevents the wearer's head organ from rendering (Lira, October 2025)
 
 #define BLOCKHEADHAIR   0x20    // Hides the user's hair overlay. Leaves facial hair.
 #define BLOCKHAIR       0x40    // Hides the user's hair, facial and otherwise.

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -7,6 +7,7 @@
 	flags = THICKMATERIAL
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
+	// RS Comment: Set HIDEHEAD in flags_inv on variants that should completely mask the wearer's head sprite (Lira, October 2025)
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HEAD

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -82,7 +82,7 @@
 	name = "Radiation hood"
 	icon_state = "rad"
 	desc = "A hood with radiation protective properties. Label: Made with lead, do not eat insulation"
-	flags_inv = BLOCKHAIR
+	flags_inv = BLOCKHAIR|HIDEHEAD // RS Edit: Precent muzzles from sticking out (Lira, October 2025)
 	item_flags = THICKMATERIAL
 	body_parts_covered = HEAD|FACE|EYES
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -146,10 +146,13 @@ This saves us from having to call add_fingerprint() any time something is put in
 		head = null
 		if(istype(W, /obj/item))
 			var/obj/item/I = W
-			if(I.flags_inv & (HIDEMASK|BLOCKHAIR|BLOCKHEADHAIR))
+			if(I.flags_inv & (HIDEMASK|BLOCKHAIR|BLOCKHEADHAIR|HIDEHEAD)) // RS Edit: Hide head (Lira, October 2025)
 				update_hair(0)	//rebuild hair
 				update_inv_ears(0)
 				update_inv_wear_mask(0)
+				// RS Edit: Hidge head (Lira, October 2025)
+				if(I.flags_inv & HIDEHEAD)
+					update_icons_body()
 		update_inv_head()
 	else if (W == l_ear)
 		l_ear = null
@@ -170,9 +173,12 @@ This saves us from having to call add_fingerprint() any time something is put in
 		wear_mask = null
 		if(istype(W, /obj/item))
 			var/obj/item/I = W
-			if(I.flags_inv & (BLOCKHAIR|BLOCKHEADHAIR))
+			if(I.flags_inv & (BLOCKHAIR|BLOCKHEADHAIR|HIDEHEAD)) // RS Edit: Hide head (Lira, October 2025)
 				update_hair(0)	//rebuild hair
 				update_inv_ears(0)
+				// RS Edit: Hide head (Lira, October 2025)
+				if(I.flags_inv & HIDEHEAD)
+					update_icons_body()
 		// If this is how the internals are connected, disable them
 		if(internal && !(head?.item_flags & AIRTIGHT))
 			if(internals)
@@ -310,10 +316,13 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_gloves()
 		if(slot_head)
 			src.head = W
-			if(head.flags_inv & (BLOCKHAIR|BLOCKHEADHAIR|HIDEMASK))
+			if(head.flags_inv & (BLOCKHAIR|BLOCKHEADHAIR|HIDEMASK|HIDEHEAD)) // RS Edit: Hide head (Lira, October 2025)
 				update_hair()	//rebuild hair
 				update_inv_ears(0)
 				update_inv_wear_mask(0)
+				// RS Edit: Hide head (Lira, October 2025)
+				if(head.flags_inv & HIDEHEAD)
+					update_icons_body()
 			if(istype(W,/obj/item/clothing/head/kitty))
 				W.update_icon(src)
 			W.equipped(src, slot)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -117,7 +117,7 @@ var/global/list/marking_icon_cache = list() // RS Add: Icon cache (Lira, Septemb
 	if(owner.h_style)
 		var/style = owner.h_style
 		var/datum/sprite_accessory/hair/hair_style = hair_styles_list[style]
-		if(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR))
+		if(owner.head && (owner.head.flags_inv & (BLOCKHEADHAIR | HIDEHEAD))) // RS Edit: Hide head (Lira, October 2025)
 			if(!(hair_style.flags & HAIR_VERY_SHORT))
 				hair_style = hair_styles_list["Short Hair"]
 		if(hair_style && (species.get_bodytype(owner) in hair_style.species_allowed))

--- a/code/modules/vore/appearance/update_icons_vr.dm
+++ b/code/modules/vore/appearance/update_icons_vr.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/proc/get_hair_accessory_overlay()
-	if(hair_accessory_style && !(head && (head.flags_inv & BLOCKHEADHAIR)))
+	if(hair_accessory_style && !(head && (head.flags_inv & (BLOCKHEADHAIR | HIDEHEAD)))) // RS Edit: Hide head (Lira, October 2025)
 		var/icon/hair_acc_s = icon(hair_accessory_style.icon, hair_accessory_style.icon_state)
 		if(hair_accessory_style.do_colouration)
 			hair_acc_s.Blend(rgb(src.r_ears, src.g_ears, src.b_ears), hair_accessory_style.color_blend_mode)


### PR DESCRIPTION
Adds a new flag that can be used to hide the head sprite.  Made to keep vulp and taj snoots from sticking out of helmets.  Just applied to the radiation hood for now, but is easy to set for other helmets where snoots are sticking out.

Resolves: https://github.com/TS-Rogue-Star/Rogue-Star/issues/474