### PR TITLE
Sync Shells at AI Start

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -219,6 +219,8 @@ var/list/ai_verbs_default = list(
 		show_laws()
 		to_chat(src, "<span class='filter_notice'><b>These laws may be changed by other players, or by you being the traitor.</b></span>")
 
+	sync_unassigned_shells() //RS Add: Sync unassigned shells when AI joins (Lira, October 2025)
+
 	job = "AI"
 	setup_icon()
 


### PR DESCRIPTION
Discovered that since the initial AI shell spawns before the AI joins, it doesn't get sync'd properly, and law lists can diverge.  This creates a new proc to sync unassigned shells to the AI when an AI joins.