### PR TITLE
AI Shell Portal Guards

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -166,6 +166,17 @@
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(ismob(M) && isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			var/turf/source_turf = get_turf(src)
+			var/turf/target_turf = null
+			if(com.teleport_control.locked)
+				target_turf = get_turf(com.teleport_control.locked)
+			if(!source_turf || !target_turf || !isStationLevel(source_turf.z) || !isStationLevel(target_turf.z) || !accurate)
+				to_chat(R, "<span class='warning'>The teleporter control rejects the remote shell.</span>")
+				return
 	if(istype(M, /atom/movable))
 		//VOREStation Addition Start: Prevent taurriding abuse
 		if(istype(M, /mob/living))

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -43,6 +43,17 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 	QDEL_IN(src, 30 SECONDS)
 
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(ismob(M) && isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			var/turf/source_turf = get_turf(src)
+			var/turf/target_turf = null
+			if(target)
+				target_turf = get_turf(target)
+			if(!source_turf || !target_turf || !isStationLevel(source_turf.z) || !isStationLevel(target_turf.z))
+				to_chat(R, "<span class='warning'>The portal destabilizes around the remote shell and shunts it away.</span>")
+				return
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
 	if (M.anchored&&istype(M, /obj/mecha))

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -144,6 +144,13 @@ GLOBAL_DATUM(gateway_station, /obj/machinery/gateway/centerstation)
 	if(!active)		return
 	if(!awaygate)	return
 
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(ismob(M) && isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			to_chat(R, "<span class='warning'>The gateway flickers and refuses the remote shell.</span>")
+			return
+
 	use_power(5000)
 	M << 'sound/effects/phasein.ogg'
 	playsound(src, 'sound/effects/phasein.ogg', 100, 1)
@@ -335,6 +342,12 @@ GLOBAL_DATUM(gateway_away, /obj/machinery/gateway/centeraway)
 /obj/machinery/gateway/centeraway/Bumped(atom/movable/M as mob|obj)
 	if(!ready)	return
 	if(!active)	return
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(ismob(M) && isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			to_chat(R, "<span class='warning'>The gateway flickers and refuses the remote shell.</span>")
+			return
 	if(istype(M, /mob/living/carbon))
 		for(var/obj/item/weapon/implant/exile/E in M)//Checking that there is an exile implant in the contents
 			if(E.imp_in == M)//Checking that it's actually implanted vs just in their pocket

--- a/code/modules/awaymissions/redgate.dm
+++ b/code/modules/awaymissions/redgate.dm
@@ -20,6 +20,7 @@
 		/mob/living/simple_mob/vore/overmap/stardog,
 		/mob/living/simple_mob/vore/bigdragon,
 		/mob/living/silicon/ai,	//RS EDIT
+		/mob/living/silicon/robot/ai_shell,	// RS Add: Shells can't leave the station (Lira, October 2025)
 		/mob/observer/eye	//RS EDIT
 		)	//There are some things we don't want to come through no matter what.
 
@@ -35,6 +36,12 @@
 	return ..()
 
 /obj/machinery/cryopod/robot/door/gateway/redgate/proc/teleport(var/mob/M as mob)
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			to_chat(R, "<span class='warning'>The [src] rejects the remote shell and remains inert.</span>")
+			return
 	var/keycheck = TRUE
 	if(!isliving(M))		//We only want mob/living, no bullets or mechs or AI eyes or items
 		if(M.type in exceptions)

--- a/code/modules/multiz/portals_vr.dm
+++ b/code/modules/multiz/portals_vr.dm
@@ -143,6 +143,17 @@
 		return	//RS EDIT
 	if(isAI(M) || istype(M,/mob/observer/eye))	//RS EDIT
 		return	//RS EDIT
+	// RS Add: Shells can't leave the station (Lira, October 2025)
+	if(ismob(M) && isrobot(M))
+		var/mob/living/silicon/robot/R = M
+		if(R.shell)
+			var/turf/source_turf = get_turf(src)
+			var/turf/target_turf = null
+			if(target)
+				target_turf = get_turf(target)
+			if(!source_turf || !target_turf || !isStationLevel(source_turf.z) || !isStationLevel(target_turf.z))
+				to_chat(R, "<span class='warning'>The [src] flares and refuses the remote shell.</span>")
+				return
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
 	if (M.anchored&&istype(M, /obj/mecha))


### PR DESCRIPTION
Fixes issues with AI Shells and portals by placing guards that prevent shells from going through portals that take them off the station z's.  Previously this was kicking the AI out of the shell and making it hard to recover.

Resolves: https://github.com/TS-Rogue-Star/Rogue-Star/issues/516