### PR TITLE
Attempt to fix vore-based shadekin energy gain

### DIFF
--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		if(!L.ckey)
 			modified_damage_gain = modified_damage_gain / 4
 
-		howner.shadekin_adjust_energy(damage_gain,TRUE) 	//1dmg to 1 energy, more or less.
+		howner.shadekin_adjust_energy(modified_damage_gain,TRUE) 	//1dmg to 1 energy, more or less.
 
 	// End RS edit
 	if(isrobot(B.owner))


### PR DESCRIPTION
Attempt at fixing #949 

TL;DR:
1) Shadekin never gained any energy digesting unless their belly sprite size was influenced by the health of their prey, which seems wrong.
2) Time was spent calculated a modified damage gain, but it was never used. The modified gain should now be in effect.

Alternatively, it could be that the reporting party's nutrition was hovering around 1000, dropping below as the proc is called to set shadekin energy. If that's the case, the only solution would be to either increase their nutrition by consuming other items, or increase the damage applied.

~~_Alternatively, a check could be implemented to bypass the nutrition check if the species is shadekin, and their eyes' primary color is red. But that's beyond the scope of my decision making._~~