### PR TITLE
Add missing APC cable in AI/Civilian Substation

### DIFF
--- a/maps/groundbase/rp-z1.dmm
+++ b/maps/groundbase/rp-z1.dmm
@@ -27358,6 +27358,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/maintenance/groundbase/substation/aiciv)
 "xLA" = (


### PR DESCRIPTION
The APC lasts all round without the cable, but it should probably be fixed.