### PR TITLE
Mounted Flasher Fix

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -56,11 +56,11 @@
 	last_flash = world.time
 	use_power(1500)
 
-	for(var/mob/living/O in oviewers(range,src))
+	for(var/mob/living/O in oviewers(range,src)) // RS EDIT
 		if(O.is_incorporeal())
 			continue
 
-		var/flash_time = strength // RS EDIT
+		var/flash_time = strength // RS EDIT START
 		if(istype(O, /mob/living/carbon/human)) // NIF Check!
 			var/mob/living/carbon/human/L = O
 			if(L.nif && L.nif.flag_check(NIF_V_FLASHPROT,NIF_FLAGS_VISION))
@@ -105,7 +105,7 @@
 /obj/machinery/flasher/portable/process() // RS ADD
 	if(disable || !anchored || (last_flash && world.time < last_flash + 150))
 		return
-	for (var/mob/living/O in oviewers(range,src))
+	for (var/mob/living/O in oviewers(range,src)) // RS EDIT
 		if (O.m_intent != "walk" && !(O.is_incorporeal()) && !(O.lying))
 			flash()
 


### PR DESCRIPTION
To the dismay of any/all secmains, The mounted flashers don't actually activate! This PR fixes that.

Mounted flashers now look within a distance of two tiles for any standing, running, non-phased targets, and flashes them. They aren't hard to avoid (sunglasses, crawling, phasing, just walking), so they're pretty potent.

Some of this (lines 79-85) borrows from the code for handheld flashers, and the rest is me schizophrenically jumping through BYOND documentation after reading through the code for portable turrets.

Testing Evidence:

<img width="294" height="199" alt="image" src="https://github.com/user-attachments/assets/81b5ae4e-1daa-4b7d-a2bd-70326060dbf8" />
<img width="172" height="240" alt="image" src="https://github.com/user-attachments/assets/481ca3e7-e8ec-4d62-876f-9cc8df8077bb" />
<img width="225" height="147" alt="image" src="https://github.com/user-attachments/assets/3cf58931-32fc-4763-a6ea-1bd6e3dd5070" />
<img width="149" height="141" alt="image" src="https://github.com/user-attachments/assets/0d3d2405-bbf5-4c37-a1c6-c67644d777c6" />
<img width="393" height="322" alt="image" src="https://github.com/user-attachments/assets/7acbc323-7e7a-4499-b289-0311cdbc343a" />
