### PR TITLE
Player Data Export

### DIFF
--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -1,6 +1,6 @@
 /datum/category_item/player_setup_item/player_global/pai
 	name = "pAI"
-	sort_order = 3
+	sort_order = 4 // RS Edit: Tweaked for menu order (Lira, January 2026)
 
 	var/datum/paiCandidate/candidate
 

--- a/code/modules/client/preference_setup/global/04_ooc.dm
+++ b/code/modules/client/preference_setup/global/04_ooc.dm
@@ -1,6 +1,6 @@
 /datum/category_item/player_setup_item/player_global/ooc
 	name = "OOC"
-	sort_order = 4
+	sort_order = 3 // RS Edit: Tweaked for menu order (Lira, January 2026)
 
 /datum/category_item/player_setup_item/player_global/ooc/load_preferences(var/savefile/S)
 	S["ignored_players"]	>> pref.ignored_players

--- a/code/modules/client/preference_setup/global/05_export.dm
+++ b/code/modules/client/preference_setup/global/05_export.dm
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+// Created by Lira for Rogue Star January 2026: Export player save data //
+//////////////////////////////////////////////////////////////////////////
+
+GLOBAL_VAR_INIT(preferences_export_round_id, 1)
+
+/hook/roundend/proc/advance_preferences_export_round()
+	GLOB.preferences_export_round_id++
+	return 1
+
+/datum/category_item/player_setup_item/player_global/save_data
+	name = "Save Data"
+	sort_order = 5
+
+/datum/category_item/player_setup_item/player_global/save_data/content(var/mob/user)
+	. = "<b>Save Data:</b><br>"
+	. += "Exports character data for all slots: <a href='?src=\ref[src];export_prefs=1'>Export</a><br>"
+
+/datum/category_item/player_setup_item/player_global/save_data/OnTopic(var/href, var/list/href_list, var/mob/user)
+	if(href_list["export_prefs"])
+		if(!CanUseTopic(user))
+			return TOPIC_NOACTION
+		if(!ticker || ticker.current_state == GAME_STATE_INIT)
+			to_chat(user, "<span class='warning'>Save data export is unavailable during server initialization.</span>")
+			return TOPIC_NOACTION
+		if(IsGuestKey(user.key))
+			to_chat(user, "<span class='warning'>Guests cannot export save data.</span>")
+			return TOPIC_NOACTION
+		if(pref.last_preferences_export_round_id == GLOB.preferences_export_round_id)
+			to_chat(user, "<span class='warning'>You can only export save data once per round.</span>")
+			return TOPIC_NOACTION
+		if(!pref.path || !fexists(pref.path))
+			to_chat(user, "<span class='warning'>No saved preferences were found to export.</span>")
+			return TOPIC_NOACTION
+
+		var/export_ckey = pref.client_ckey
+		if(!export_ckey)
+			export_ckey = user.ckey
+		if(!export_ckey)
+			export_ckey = "player"
+
+		var/export_name = "preferences_[export_ckey].sav"
+		user << ftp(file(pref.path), export_name)
+		pref.last_preferences_export_round_id = GLOB.preferences_export_round_id
+		log_debug("[key_name(user)] exported preferences.sav via character setup.")
+		to_chat(user, "<span class='notice'>Save data export started.</span>")
+		return TOPIC_NOACTION
+
+	return ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -198,6 +198,7 @@ var/list/preferences_datums = list()
 
 	///If they are currently in the process of swapping slots, don't let them open 999 windows for it and get confused
 	var/selecting_slots = FALSE
+	var/last_preferences_export_round_id = 0 // RS Add: Export gating (Lira, January 2026)
 
 /datum/preferences/New(client/C)
 	player_setup = new(src)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1998,6 +1998,7 @@
 #include "code\modules\client\preference_setup\global\02_settings.dm"
 #include "code\modules\client\preference_setup\global\03_pai.dm"
 #include "code\modules\client\preference_setup\global\04_ooc.dm"
+#include "code\modules\client\preference_setup\global\05_export.dm"
 #include "code\modules\client\preference_setup\global\setting_datums.dm"
 #include "code\modules\client\preference_setup\loadout\gear_tweaks.dm"
 #include "code\modules\client\preference_setup\loadout\gear_tweaks_rs.dm"


### PR DESCRIPTION
Allows players to export their character save data.  No longer do you need to poke the admin team for a copy.  As a future improvement, I'll add a tool for loading and selectively restoring slots, allowing people to maintain and manage their own backups. 