### PR TITLE
Arrivals Notification Update

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -141,9 +141,17 @@
 /proc/ion_storm_announcement()
 	command_announcement.Announce("It has come to our attention that \the [station_name()] passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert")
 
+// RS Add: Arrivals Notification Z-Fix (Lira, April 2026)
+/proc/GetArrivalAnnouncementZlevels(var/zlevel, var/channel = "Common")
+	if(!zlevel)
+		return null
+	if(channel == "Common" && (zlevel in using_map.station_levels))
+		return get_station_network_zlevels(channel)
+	return using_map.get_map_levels(zlevel, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
+
 /proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank, var/join_message, var/channel = "Common", var/zlevel)
 	if (ticker.current_state == GAME_STATE_PLAYING)
-		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE, om_range = DEFAULT_OVERMAP_RANGE) : null
+		var/list/zlevels = GetArrivalAnnouncementZlevels(zlevel, channel) // RS Edit: Arrivals Notification Z-Fix (Lira, April 2026)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		AnnounceArrivalSimple(character.real_name, rank, join_message, channel, zlevels)

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -13,6 +13,71 @@
 	if(radio_controller)
 		radio_controller.remove_object(source, frequency)
 
+// RS Add: Arrivals Notification Z-Fix (Lira, April 2026)
+/proc/get_telecomms_reachable_zlevels(var/source_z, var/channel = "Common")
+	if(!source_z || !radio_controller)
+		return list()
+
+	var/frequency = radiochannels[channel]
+	if(!frequency)
+		return list()
+
+	var/datum/signal/signal = new
+	signal.transmission_method = TRANSMISSION_SUBSPACE
+	signal.frequency = frequency
+	signal.data = list(
+		"slow" = 0,
+		"message" = "TELECOMMS_PROBE_[world.time]_[source_z]_[frequency]_[rand(1, 1000000)]",
+		"compression" = 0,
+		"traffic" = 0,
+		"type" = SIGNAL_TEST,
+		"reject" = 0,
+		"done" = 0,
+		"level" = source_z,
+		"realname" = "telecomms probe"
+	)
+
+	for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
+		R.receive_signal(signal)
+
+	if(!signal.data["done"] && using_map.use_overmap)
+		for(var/obj/machinery/telecomms/allinone/A in telecomms_list)
+			if(!A.on)
+				continue
+			if(!A.is_freq_listening(signal))
+				continue
+
+			var/list/map_levels = using_map.get_map_levels(A.z, TRUE, A.overmap_range)
+			var/list/signal_levels = list()
+			signal_levels += signal.data["level"]
+			var/list/overlap = map_levels & signal_levels
+			if(!overlap.len)
+				continue
+
+			signal.data["done"] = 1
+			signal.data["compression"] = 0
+			signal.data["level"] = map_levels
+			break
+
+	var/list/reachable_levels = list()
+	if(islist(signal.data["level"]))
+		reachable_levels |= signal.data["level"]
+	else if(signal.data["level"])
+		reachable_levels += signal.data["level"]
+
+	return reachable_levels
+
+// RS Add: Arrivals Notification Z-Fix (Lira, April 2026)
+/proc/get_station_network_zlevels(var/channel = "Common")
+	var/list/reachable_levels = using_map.station_levels.Copy()
+	if(!reachable_levels.len)
+		return reachable_levels
+
+	for(var/source_z in using_map.station_levels)
+		reachable_levels |= get_telecomms_reachable_zlevels(source_z, channel)
+
+	return reachable_levels
+
 /proc/get_frequency_name(var/display_freq)
 	var/freq_text
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -549,7 +549,7 @@
 		depart_announce = FALSE
 
 	if(announce_leaving && depart_announce)
-		announce.autosay("[to_despawn.real_name][departing_job ? ", [departing_job], " : " "][on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
+		announce.autosay("[to_despawn.real_name][departing_job ? ", [departing_job], " : " "][on_store_message]", "[on_store_name]", announce_channel, GetArrivalAnnouncementZlevels(z, announce_channel)) // RS Edit: Arrivals Notification Z-Fix (Lira, April 2026)
 		visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2]</span>", 3)
 
 	//VOREStation Edit End

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -530,7 +530,7 @@
 
 /mob/new_player/proc/AnnounceCyborg(var/mob/living/character, var/rank, var/join_message, var/channel, var/zlevel)
 	if (ticker.current_state == GAME_STATE_PLAYING)
-		var/list/zlevels = zlevel ? using_map.get_map_levels(zlevel, TRUE, om_range = DEFAULT_OVERMAP_RANGE) : null
+		var/list/zlevels = GetArrivalAnnouncementZlevels(zlevel, channel) // RS Edit: Arrivals Notification Z-Fix (Lira, April 2026)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.


### PR DESCRIPTION
Updates the logic for the arrivals notifications.  They will continue to work on all station z's regardless of power, but now work on other z's on the station coms network like the red gate.