### PR TITLE
Area Teleport Fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -511,18 +511,28 @@ var/list/mob/living/forced_ambiance_list = new
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
 
+// RS Edit: Area Tele Cleanup (Lira, April 2026)
 /hook/startup/proc/setupTeleportLocs()
+	rebuild_teleport_locs()
+	return 1
+
+/proc/rebuild_teleport_locs(var/list/valid_levels)
+	teleportlocs = list()
+	if(!valid_levels)
+		valid_levels = using_map?.station_levels
+	if(!valid_levels || !valid_levels.len)
+		return teleportlocs
+
 	for(var/area/AR in world)
 		if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station)) continue
 		if(teleportlocs.Find(AR.name)) continue
-		var/turf/picked = pick(get_area_turfs(AR.type))
-		if (picked.z in using_map.station_levels)
-			teleportlocs += AR.name
-			teleportlocs[AR.name] = AR
+		for(var/turf/T in AR)
+			if(T.z in valid_levels)
+				teleportlocs[AR.name] = AR
+				break
 
 	teleportlocs = sortAssoc(teleportlocs)
-
-	return 1
+	return teleportlocs
 
 var/list/ghostteleportlocs = list()
 

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -22,24 +22,49 @@
 /spell/area_teleport/before_cast()
 	return
 
-/spell/area_teleport/choose_targets()
+// RS Edit: Area Tele Cleanup (Lira, April 2026)
+/spell/area_teleport/choose_targets(mob/user = usr)
+	if(!user)
+		return
+	if(!teleportlocs || !teleportlocs.len)
+		rebuild_teleport_locs()
+	if(!teleportlocs || !teleportlocs.len)
+		var/turf/user_turf = get_turf(user)
+		if(user_turf)
+			rebuild_teleport_locs(list(user_turf.z))
+	if(!teleportlocs || !teleportlocs.len)
+		to_chat(user, "<span class='warning'>The spell matrix cannot find any teleport destinations.</span>")
+		return
+
 	var/A = null
 
 	if(!randomise_selection)
-		A = tgui_input_list(usr, "Area to teleport to", "Teleport", teleportlocs)
+		A = tgui_input_list(user, "Area to teleport to", "Teleport", teleportlocs)
 	else
 		A = pick(teleportlocs)
+	if(!A)
+		return
 
-	var/area/thearea = teleportlocs[A]
+	var/area/thearea = null
+	if(isarea(A))
+		thearea = A
+	else
+		thearea = teleportlocs[A]
+	if(!thearea)
+		to_chat(user, "<span class='warning'>The spell matrix lost its destination lock. Please try again.</span>")
+		return
 
 	return list(thearea)
 
-/spell/area_teleport/cast(area/thearea, mob/user)
+// RS Edit: Area Tele Cleanup (Lira, April 2026)
+/spell/area_teleport/cast(list/targets, mob/user)
+	if(!targets || !targets.len)
+		return
+	var/area/thearea = targets[1]
 	if(!istype(thearea))
-		if(istype(thearea, /list))
-			thearea = thearea[1]
+		return
 	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea.type))
+	for(var/turf/T in get_current_area_turfs(thearea))
 		if(!T.density)
 			var/clear = 1
 			for(var/obj/O in T)
@@ -54,32 +79,35 @@
 		return
 
 	if(user && user.buckled)
-		user.buckled = null
+		user.buckled.unbuckle_mob()
 
-	var/attempt = null
+	var/list/possible_destinations = L.Copy()
+	var/turf/attempt = null
 	var/success = 0
-	while(L.len)
-		attempt = pick(L)
-		success = user.Move(attempt)
+	while(possible_destinations.len)
+		attempt = pick(possible_destinations)
+		success = user.forceMove(attempt)
 		if(!success)
-			L.Remove(attempt)
+			possible_destinations.Remove(attempt)
 		else
 			break
 
 	if(!success)
-		user.loc = pick(L)
+		to_chat(user, "The spell matrix was unable to complete the teleport. Please try again.")
 
 	return
 
 /spell/area_teleport/after_cast()
 	return
 
-/spell/area_teleport/invocation(mob/user, area/chosenarea)
-	if(!istype(chosenarea))
-		return //can't have that, can we
-	if(!invocation_area || !chosenarea)
-		..()
-	else
-		invocation += "[uppertext(chosenarea.name)]"
-		..()
-	return
+// RS Edit: Area Tele Cleanup (Lira, April 2026)
+/spell/area_teleport/invocation(mob/user, list/targets)
+	var/area/chosenarea = null
+	if(targets && targets.len)
+		chosenarea = targets[1]
+	if(!invocation_area || !istype(chosenarea))
+		return ..()
+	var/original_invocation = invocation
+	invocation = "[invocation] [uppertext(chosenarea.name)]"
+	. = ..()
+	invocation = original_invocation


### PR DESCRIPTION
Cleans up the area teleport spell so it actually works again and also no longer makes the compiler grumpy.