### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   autochangelog:
     name: Autochangelog
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true
     steps:
       - uses: /actions/checkout@v3

--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.7'
       - name: Generate Changelog

--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true
     steps:
-      - uses: /actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Update repository to master

--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -11,10 +11,10 @@ env:
 jobs:
   autochangelog:
     name: Autochangelog
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # RS Edit - use supported runner
     if: github.event.pull_request.merged == true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6 # RS Edit - use supported action version
         with:
           ref: master
       - name: Update repository to master
@@ -22,7 +22,7 @@ jobs:
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6 # RS Edit - use supported action version
         with:
           python-version: '3.7'
       - name: Generate Changelog
@@ -36,7 +36,7 @@ jobs:
           python tools/GenerateChangelog/ss13_genchangelog.py \
             html/changelog.html \
             html/changelogs
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@v7 # RS Edit - use supported action version
         with:
           commit_message: Automatic changelog generation for ${{ github.events.pull_request.number }}
           branch: ${{ github.events.pull_request.base }}

--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -36,7 +36,7 @@ jobs:
           python tools/GenerateChangelog/ss13_genchangelog.py \
             html/changelog.html \
             html/changelogs
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Automatic changelog generation for ${{ github.events.pull_request.number }}
           branch: ${{ github.events.pull_request.base }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,21 +77,21 @@ jobs:
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
-      - name: Setup Cache
-        uses: actions/cache@v5
-        with:
-          path: $HOME/BYOND
-          key: ${{ runner.os }}-byond
       - name: Install RUST_G Dependencies
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
           sudo apt install zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
           ldd librust_g.so
+      - name: Setup BYOND Cache
+        uses: actions/cache@v5
+        with:
+          path: ~/BYOND
+          key: ${{ runner.os }}-byond
+      - name: Install BYOND
+        run: tools/ci/install_byond.sh
       - name: Unit Tests
-        run: |
-          tools/ci/install_byond.sh
-          tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh
         env:
           TEST_DEFINE: "UNIT_TEST"
           TEST_FILE: "code/_unit_tests.dm"
@@ -100,9 +100,7 @@ jobs:
           EXTRA_ARGS: "-D${{ matrix.map }}"   #RS EDIT
           RUN: "1"
       - name: Compile POIs
-        run: |
-          tools/ci/install_byond.sh
-          tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh
         env:
           TEST_DEFINE: "MAP_TEST"
           TEST_FILE: "code/_map_tests.dm"
@@ -110,9 +108,7 @@ jobs:
           REPLACE: false
           RUN: "0"
       - name: Compile away missions
-        run: |
-          tools/ci/install_byond.sh
-          tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh
         env:
           TEST_DEFINE: "AWAY_MISSION_TEST"
           TEST_FILE: "code/_away_mission_tests.dm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6 # RS Edit - use supported action version
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
@@ -21,7 +21,7 @@ jobs:
           bash tools/ci/install_build_deps.sh
       - name: Restore Yarn cache
         if: "${{ contains(github.event.pull_request.labels.*.name, 'Type: TGUI Bundle') }}"
-        uses: actions/cache@v5
+        uses: actions/cache@v5 # RS Edit - use supported action version
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
@@ -38,10 +38,10 @@ jobs:
     name: DreamChecker
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6 # RS Edit - use supported action version
 
       - name: Cache SpacemanDMM
-        uses: actions/cache@v5
+        uses: actions/cache@v5 # RS Edit - use supported action version
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-dreamchecker-${{ hashFiles('_build_dependencies.sh')}} #RS Edit: Fix dependency file (Lira, August 2025)
@@ -58,7 +58,7 @@ jobs:
 
       - name: Annotate Linter
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # RS Edit - use supported node version on archived action
         uses: yogstation13/DreamAnnotate@v2
         if: always()
         with:
@@ -73,7 +73,7 @@ jobs:
     # needs: ['file_tests', 'dreamchecker']
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6 # RS Edit - use supported action version
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
@@ -83,15 +83,17 @@ jobs:
           sudo apt update || true
           sudo apt install zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
           ldd librust_g.so
+      # RS Edit - fix BYOND cache
       - name: Setup BYOND Cache
         uses: actions/cache@v5
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond
+      # RS Edit Continued - only install BYOND once
       - name: Install BYOND
         run: tools/ci/install_byond.sh
       - name: Unit Tests
-        run: tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh # RS Edit End
         env:
           TEST_DEFINE: "UNIT_TEST"
           TEST_FILE: "code/_unit_tests.dm"
@@ -100,7 +102,7 @@ jobs:
           EXTRA_ARGS: "-D${{ matrix.map }}"   #RS EDIT
           RUN: "1"
       - name: Compile POIs
-        run: tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh # RS Edit - Only install BYOND once
         env:
           TEST_DEFINE: "MAP_TEST"
           TEST_FILE: "code/_map_tests.dm"
@@ -108,7 +110,7 @@ jobs:
           REPLACE: false
           RUN: "0"
       - name: Compile away missions
-        run: tools/ci/compile_and_run.sh
+        run: tools/ci/compile_and_run.sh # RS Edit - Only install BYOND once
         env:
           TEST_DEFINE: "AWAY_MISSION_TEST"
           TEST_FILE: "code/_away_mission_tests.dm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
@@ -38,7 +38,7 @@ jobs:
     name: DreamChecker
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache SpacemanDMM
         uses: actions/cache@v3
@@ -71,7 +71,7 @@ jobs:
     # needs: ['file_tests', 'dreamchecker']
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
 
       - name: Annotate Linter
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         uses: yogstation13/DreamAnnotate@v2
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           bash tools/ci/install_build_deps.sh
       - name: Restore Yarn cache
         if: "${{ contains(github.event.pull_request.labels.*.name, 'Type: TGUI Bundle') }}"
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache SpacemanDMM
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-dreamchecker-${{ hashFiles('_build_dependencies.sh')}} #RS Edit: Fix dependency file (Lira, August 2025)
@@ -76,7 +76,7 @@ jobs:
         run: |
           chmod -R +x ./tools/ci
       - name: Setup Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: $HOME/BYOND
           key: ${{ runner.os }}-byond

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write # to create pull requests (repo-sync/pull-request)
 
     name: 'Generate NanoMaps'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Clone
       uses: actions/checkout@v4

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -46,6 +46,8 @@ jobs:
         git push -f -u origin nanomaps_generation
 
     - name: Create Pull Request
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       uses: repo-sync/pull-request@v2
       with:
         source_branch: "nanomaps_generation"

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Clone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Branch
       run: |

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: write # to create pull requests (repo-sync/pull-request)
 
     name: 'Generate NanoMaps'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # RS Edit - use supported runner
     steps:
     - name: Clone
-      uses: actions/checkout@v6
+      uses: actions/checkout@v6 # RS Edit - use supported action version
 
     - name: Branch
       run: |
@@ -47,7 +47,7 @@ jobs:
 
     - name: Create Pull Request
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # RS Edit - use supported node version on archived action
       uses: repo-sync/pull-request@v2
       with:
         source_branch: "nanomaps_generation"

--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -2,7 +2,7 @@
 # For dreamchecker
 export SPACEMAN_DMM_VERSION=suite-1.10 #RS Edit: Updated from version 1.7 to 1.10 (Lira, August 2025)
 # For NanoUI + TGUI
-export NODE_VERSION=20 #RS EDIT
+export NODE_VERSION=22 #RS EDIT
 # Byond Major
 export BYOND_MAJOR=516 #RS EDIT
 # Byond Minor


### PR DESCRIPTION
Update ahead of Node 20 EoL at the end of the month:

Update GitHub Actions agent to Ubuntu 22 (previous agent is no longer supported).
Update GitHub Actions to use Node 22.
Update _build_dependencies to point to Node 22.
Fix BYOND caching in CI.
Reduce calls to `install_byond` in CI.