### PR TITLE
Remove Who, rename Advanced Who to Who

### DIFF
--- a/code/modules/client/verbs/advanced_who.dm
+++ b/code/modules/client/verbs/advanced_who.dm
@@ -1,6 +1,6 @@
 
 /client/verb/who_advanced()
-	set name = "Advanced Who"
+	set name = "Who"	//RS EDIT
 	set category = "OOC"
 
 	var/msg = "<b>Current Players:</b>\n"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -1,3 +1,4 @@
+/*	//RS REMOVE
 /client/verb/who()
 	set name = "Who"
 	set category = "OOC"
@@ -53,7 +54,7 @@
 	msg += "<b>Total Players: [length(Lines)]</b>"
 	msg = "<span class='filter_notice'>[jointext(msg, "<br>")]</span>"
 	to_chat(src,msg)
-
+*/
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"


### PR DESCRIPTION
## PR Purpose and Benefit
<!-- Explain the purpose of this PR and how it benefits the server. -->
Comments out who, renames advanced who to who.

Both do the same thing, advanced who is just a better version of who, so I figured why not