### PR TITLE
Aghost In No Ghost Areas Fix

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,13 +69,17 @@
 		var/mob/observer/dead/ghost
 		if(build_mode)
 			togglebuildmode(body)
-			ghost = body.ghostize(1)
+		// RS Edit Start: Fix aghost in ghost blocked areas (Lira, April 2026)
+		ghost = body.ghostize(1)
+		if(ghost)
 			ghost.admin_ghosted = 1
-			if(build_mode == "Yes")
-				togglebuildmode(ghost)
-		else
-			ghost = body.ghostize(1)
-			ghost.admin_ghosted = 1
+			var/turf/body_turf = get_turf(body)
+			if(body_turf)
+				ghost.forceMove(body_turf)
+			ghost.reset_view(null)
+		if(ghost && build_mode == "Yes")
+			togglebuildmode(ghost)
+		// RS Edit End
 		if(body)
 			body.teleop = ghost
 			if(!body.key)


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes a bug that caused the camera to stay locked on the mob when an admin aghosts in an area with ghost protections.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested locally to confirm the change behaves as expected.