### PR TITLE
Turn Off Dead Chat For Scrying Orb

### DIFF
--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -21,8 +21,14 @@
 	to_chat(user, "<span class='info'>You can see... everything!</span>")
 	visible_message("<span class='danger'>[user] stares into [src], their eyes glazing over.</span>")
 
-	user.teleop = user.ghostize(1)
-	announce_ghost_joinleave(user.teleop, 1, "You feel that they used a powerful artifact to [pick("invade","disturb","disrupt","infest","taint","spoil","blight")] this place with their presence.")
+	// RS Edit Start: No dchat for scrying ghosts (Lira, April 2026)
+	var/mob/observer/dead/scrying_ghost = user.ghostize(1)
+	if(!scrying_ghost)
+		return
+	scrying_ghost.forbid_seeing_deadchat = TRUE
+	user.teleop = scrying_ghost
+	announce_ghost_joinleave(scrying_ghost, 1, "You feel that they used a powerful artifact to [pick("invade","disturb","disrupt","infest","taint","spoil","blight")] this place with their presence.")
+	// RS Edit End
 	return
 
 // RS Add: Universal wizard (Lira, April 2026)


### PR DESCRIPTION
## PR Purpose and Benefit
The scrying orb allows someone to move around as a ghost.  This change removes access to using and hearing deadchat, since dead chat is OOC and the use of the orb is IC.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
PR worked as intended in local testing.