### PR TITLE
Multi-Z Coms Fix

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -321,7 +321,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			var/list/relayed_levels = list()
 			for(var/obj/machinery/telecomms/relay/R in H.links)
 				if(R.can_receive(signal))
-					relayed_levels |= R.listening_level
+					relayed_levels |= using_map.get_map_levels(R.listening_level) // RS Edit: Multi-Z Coms Fix (Lira, May 2026)
 			if(signal.data["level"] in relayed_levels)
 				return 1
 		return 0


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes sending messages over coms on non-station maps that have multiple z areas.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [X] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and confirmed this works as intended locally.