### PR TITLE
Storm Staff Sound Tweak

### DIFF
--- a/code/modules/projectiles/guns/magic/storm.dm
+++ b/code/modules/projectiles/guns/magic/storm.dm
@@ -61,11 +61,7 @@
 	new /obj/effect/temporary_effect/lightning_strike(T)
 	playsound(T, 'sound/effects/lightningbolt.ogg', 100, 1)
 
-	var/sound = get_sfx("thunder")
-	for(var/mob/M in player_list)
-		if((P && (M.z in P.expected_z_levels)) || M.z == T.z)
-			if(M.is_preference_enabled(/datum/client_preference/weather_sounds))
-				M.playsound_local(get_turf(M), soundin = sound, vol = 70, vary = FALSE, is_global = TRUE)
+	playsound(T, "thunder", 70, FALSE)
 
 	for(var/atom/movable/AM in range(STORM_STAFF_LIGHTNING_RANGE, T))
 		if(isliving(AM))


### PR DESCRIPTION
## PR Purpose and Benefit
Tweaks the storm staff so the lightning sound is positional and not over the entire z.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested locally and works as expected.