### PR TITLE
Skybox Overmap Fix

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -38,11 +38,21 @@
 
 	var/turf/T = get_turf(eye)
 	if(T)
+		// RS Add Start: Skybox Overmap Fix (Lira, June 2026)
+		var/skybox_z = T.z
+		var/turf/position_turf = T
+		if(istype(eye, /obj/effect/overmap/visitable))
+			var/obj/effect/overmap/visitable/overmap_eye = eye
+			var/turf/mob_turf = get_turf(mob)
+			if(mob_turf && (mob_turf.z in overmap_eye.map_z))
+				skybox_z = mob_turf.z
+				position_turf = mob_turf
+		// RS Add End
 		if(rebuild)
 			skybox.cut_overlays()
-			skybox.add_overlay(SSskybox.get_skybox(T.z))
+			skybox.add_overlay(SSskybox.get_skybox(skybox_z)) // RS Edit: Skybox Overmap Fix (Lira, June 2026)
 			screen |= skybox
-		skybox.screen_loc = "CENTER:[(world.maxx>>1) - T.x],CENTER:[(world.maxy>>1) - T.y]"
+		skybox.screen_loc = "CENTER:[(world.maxx>>1) - position_turf.x],CENTER:[(world.maxy>>1) - position_turf.y]" // RS Edit: Skybox Overmap Fix (Lira, June 2026)
 
 /mob/Login()
 	. = ..()


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes a bug where the skybox doesn't correctly render when crossing onto a planet turf when the client eye is on the overmap.

Resolves: https://github.com/TS-Rogue-Star/Rogue-Star/issues/1361


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and works locally.