### PR TITLE
Fix Init Order Runtime

### DIFF
--- a/code/modules/busy_space_vr/organizations.dm
+++ b/code/modules/busy_space_vr/organizations.dm
@@ -380,11 +380,25 @@
 
 /datum/lore/organization/tsc/nanotrasen/New()
 	..()
-	spawn(1) // BYOND shenanigans means using_map is not initialized yet.  Wait a tick.
-		// Get rid of the current map from the list, so ships flying in don't say they're coming to the current map.
-		var/string_to_test = "[using_map.station_name] in [using_map.starsys_name]"
-		if(string_to_test in destination_names)
-			destination_names.Remove(string_to_test)
+	prune_current_map_destination() // RS Add: Fix Init Order Runtime (Lira, June 2026)
+
+// RS Edit: Fix Init Order Runtime (Lira, June 2026)
+/datum/lore/organization/tsc/nanotrasen/proc/prune_current_map_destination()
+	if(!using_map)
+		return
+
+	// Get rid of the current map from the list, so ships flying in don't say they're coming to the current map.
+	var/string_to_test = "[using_map.station_name] in [using_map.starsys_name]"
+	if(string_to_test in destination_names)
+		destination_names.Remove(string_to_test)
+
+// RS Add: Fix Init Order Runtime (Lira, June 2026)
+/proc/prune_current_map_from_lore_destinations()
+	if(!using_map || !loremaster?.organizations)
+		return
+
+	var/datum/lore/organization/tsc/nanotrasen/nanotrasen = loremaster.organizations[/datum/lore/organization/tsc/nanotrasen]
+	nanotrasen?.prune_current_map_destination()
 
 /datum/lore/organization/tsc/hephaestus
 	name = "Hephaestus Industries"

--- a/maps/~map_system/maps_rs.dm
+++ b/maps/~map_system/maps_rs.dm
@@ -69,6 +69,7 @@ var/global/list/possible_station_maps = list(
 
 	if(using_map)
 		setup_fax_admin_departments() // Fax machine fix (Lira, March 2026)
+		prune_current_map_from_lore_destinations() // RS Add: Fix Init Order Runtime (Lira, June 2026)
 		log_debug("[using_map.name] was created successfully.")
 	else
 		error("initialise_map_list() failed to create a map object. No maps will load.")


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes an init order runtime by making destination pruning explicitly after map selection.  We don't use the radio traffic this is a part of, so has no impact other than removing a runtime.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and works locally.