### PR TITLE
Replacement Marking Fix

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -209,7 +209,12 @@
 	if(owner?.ignore_sprite_accessory_body_hide)
 		return 0
 	for(var/M in markings)
-		var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
+		// RS Edit Start: Fix markings bug (Lira, June 2026)
+		var/list/mark_data = markings[M]
+		if(!islist(mark_data) || !mark_data["on"])
+			continue
+		var/datum/sprite_accessory/marking/mark_style = mark_data["datum"]
+		// RS Edit End
 		if(istype(mark_style,/datum/sprite_accessory/marking) && (organ_tag in mark_style.hide_body_parts))
 			return 1
 
@@ -1435,6 +1440,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return 1
 	if(clothing_only && markings.len)
 		for(var/M in markings)
-			var/datum/sprite_accessory/marking/mark = markings[M]["datum"]
-			if(mark.hide_body_parts && (organ_tag in mark.hide_body_parts))
+			// RS Edit Start: Fix markings bug (Lira, June 2026)
+			var/list/mark_data = markings[M]
+			if(!islist(mark_data) || !mark_data["on"])
+				continue
+			var/datum/sprite_accessory/marking/mark = mark_data["datum"]
+			if(istype(mark, /datum/sprite_accessory/marking) && mark.hide_body_parts && (organ_tag in mark.hide_body_parts))
+			// RS Edit End
 				return 1


### PR DESCRIPTION
## PR Purpose and Benefit
When a marking that replaces body parts is selected, fixes it so that it does not remove parts for any disabled parts of the marking.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested fix locally and confirmed it acts as expected.