### PR TITLE
Chat Timestamp Preference Migration

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -93,7 +93,6 @@
 	)
 	. += "<b>TGUI Message Window Size:</b> <a href='?src=\ref[src];tgui_input_window_scale=1'><b>[tgui_input_window_scale_labels[pref.tgui_input_window_scale]]</b></a><br>"
 	// RS Add End
-	. += "<b>Chat Timestamps:</b> <a href='?src=\ref[src];chat_timestamps=1'><b>[(pref.chat_timestamp) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b>"
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -186,10 +185,6 @@
 		if(!choice || !CanUseTopic(user))
 			return TOPIC_NOACTION
 		pref.tgui_input_window_scale = window_scale_options.Find(choice)
-		return TOPIC_REFRESH
-
-	else if(href_list["chat_timestamps"])
-		pref.chat_timestamp = !pref.chat_timestamp
 		return TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -218,6 +218,18 @@
 			)
 			insert_preference(group_preferences, preference_entry)
 
+		if(group == PREFERENCE_SETTINGS_GROUP_CHAT)
+			var/list/chat_timestamps_entry = list(
+				"key" = "CHAT_TIMESTAMPS",
+				"label" = "Chat Timestamps",
+				"enabled" = user.client.prefs.chat_timestamp ? TRUE : FALSE,
+				"enabled_label" = "Enabled",
+				"disabled_label" = "Disabled",
+				"tooltip" = "Toggles whether or not messages in chat will display timestamps. Enabling this will not add timestamps to messages that have already been sent.",
+				"sort_order" = 45
+			)
+			insert_preference(group_preferences, chat_timestamps_entry)
+
 		if(length(group_preferences))
 			. += list(list(
 				"name" = group,
@@ -294,6 +306,17 @@
 	switch(action)
 		if("set_preference")
 			var/preference_key = params["key"]
+			if(preference_key == "CHAT_TIMESTAMPS")
+				var/enabled = param_number(params["enabled"], FALSE)
+				if(enabled == (usr.client.prefs.chat_timestamp ? TRUE : FALSE))
+					return FALSE
+				if(!can_accept_toggle_action())
+					return FALSE
+
+				usr.client.prefs.chat_timestamp = enabled ? TRUE : FALSE
+				schedule_preferences_save()
+				return TRUE
+
 			var/datum/client_preference/client_pref = get_client_preference(preference_key)
 			if(!client_pref || !client_pref.settings_panel_group || client_pref.sound_panel_group || !client_pref.may_toggle(usr))
 				return FALSE

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -422,6 +422,7 @@
 /client/verb/toggle_chat_timestamps()
 	set name = "Toggle Chat Timestamps"
 	set category = "Preferences"
+	set hidden = TRUE // RS Add: Preference settings panel (Lira, July 2026)
 	set desc = "Toggles whether or not messages in chat will display timestamps. Enabling this will not add timestamps to messages that have already been sent."
 
 	prefs.chat_timestamp = !prefs.chat_timestamp	//There is no preference datum for tgui input lock, nor for any TGUI prefs.


### PR DESCRIPTION
## PR Purpose and Benefit
Moves the chat timestamp preference into the new preference panel.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and works locally.