### PR TITLE
Gravity Event Fix

### DIFF
--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -14,7 +14,11 @@
 			generators += GG
 
 	if(generators.len)
-		endWhen = rand(5 MINUTES, 20 MINUTES)
+		// RS Edit Start: Gravity Event Fix (Lira, July 2026)
+		var/minimum_duration = round((5 MINUTES) / SSevents.wait)
+		var/maximum_duration = round((20 MINUTES) / SSevents.wait)
+		endWhen = rand(minimum_duration, maximum_duration)
+		// RS Edit End
 	else
 		endWhen = rand(15, 60)
 
@@ -47,7 +51,7 @@
 		var/did_anything = FALSE
 		if(generators.len)
 			for(var/obj/machinery/gravity_generator/main/GG in generators)
-				if(!GG.on)
+				if(!GG.on || !GG.breaker) // RS Edit: Gravity Event Fix (Lira, July 2026)
 					GG.breaker = TRUE
 					GG.set_power()
 					GG.charge_count = 90

--- a/code/modules/gamemaster/event2/events/everyone/gravity_vr.dm
+++ b/code/modules/gamemaster/event2/events/everyone/gravity_vr.dm
@@ -35,7 +35,7 @@
 	
 	var/did_anything = FALSE
 	for(var/obj/machinery/gravity_generator/main/GG in generators)
-		if(!GG.on)
+		if(!GG.on || !GG.breaker) // RS Edit: Gravity Event Fix (Lira, July 2026)
 			GG.breaker = TRUE
 			GG.set_power()
 			GG.charge_count = 90

--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -312,6 +312,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 // Set the state of the gravity.
 /obj/machinery/gravity_generator/main/proc/set_state(new_state)
 	charging_state = POWER_IDLE
+	on = new_state // RS Add: Gravity Event Fix (Lira, July 2026)
 	update_use_power(new_state ? USE_POWER_ACTIVE : USE_POWER_IDLE)
 
 	// Sound the alert if gravity was just enabled or disabled.


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes the Stellar Delight gravity event so it ends after 5 to 20 minutes as intended.


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and works on local.