### PR TITLE
Fix Examine Mode

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -270,10 +270,29 @@
 		else
 			f_name += "oil-stained [name][infix]."
 
-	var/list/output = list("\icon[src.examine_icon()][bicon(src)] That's [f_name] [suffix]", get_examine_desc())
+	// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+	var/examine_description = get_examine_desc()
+	var/list/output = list("\icon[src.examine_icon()][bicon(src)] That's [f_name] [suffix]", examine_description)
 
 	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
-		output += description_info
+		var/extra_description_info = get_description_info()
+		if(extra_description_info)
+			output += span_info("<b>[extra_description_info]</b>")
+
+		var/list/description_interactions = get_description_interaction(TRUE)
+		if(description_interactions)
+			for(var/description_interaction in description_interactions)
+				output += span_info("<b>[description_interaction]</b>")
+
+		var/extra_description_fluff = get_description_fluff()
+		if(extra_description_fluff && extra_description_fluff != examine_description)
+			output += span_green("<b>[extra_description_fluff]</b>")
+
+		if(((user.mind && user.mind.special_role) || isobserver(user)))
+			var/extra_description_antag = get_description_antag()
+			if(extra_description_antag)
+				output += span_danger("<b>[extra_description_antag]</b>")
+	// RS Edit End
 
 	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
 		user.client.statpanel = "Examine" // Switch to stat panel

--- a/code/game/machinery/pointdefense.dm
+++ b/code/game/machinery/pointdefense.dm
@@ -31,10 +31,11 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 		circuit = new circuit(src)
 	default_apply_parts()
 
-/obj/machinery/pointdefense_control/get_description_interaction()
-	. = ..()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/machinery/pointdefense_control/get_description_interaction(var/for_chat = FALSE)
+	. = ..(for_chat)
 	if(!id_tag)
-		. += "[desc_panel_image("multitool")]to set ident tag"
+		. += "[desc_panel_image("multitool", for_chat)]to set ident tag"
 
 /obj/machinery/pointdefense_control/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -155,10 +156,11 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 	if(powernet)
 		. += "It is connected to a power cable below."
 
-/obj/machinery/power/pointdefense/get_description_interaction()
-	. = ..()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/machinery/power/pointdefense/get_description_interaction(var/for_chat = FALSE)
+	. = ..(for_chat)
 	if(!id_tag)
-		. += "[desc_panel_image("multitool")]to set ident tag and connect to a mainframe."
+		. += "[desc_panel_image("multitool", for_chat)]to set ident tag and connect to a mainframe."
 
 /obj/machinery/power/pointdefense/update_icon()
 	if(!active || !id_tag || inoperable())

--- a/code/game/objects/items/weapons/melee/shock_maul.dm
+++ b/code/game/objects/items/weapons/melee/shock_maul.dm
@@ -263,14 +263,15 @@
 		update_held_icon()
 	..()
 
-/obj/item/weapon/melee/shock_maul/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/item/weapon/melee/shock_maul/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
 	if(bcell)
-		results += "[desc_panel_image("offhand")]to remove the weapon cell."
+		results += "[desc_panel_image("offhand", for_chat)]to remove the weapon cell."
 	else
-		results += "[desc_panel_image("weapon cell")]to add a new weapon cell."
+		results += "[desc_panel_image("weapon cell", for_chat)]to add a new weapon cell."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -263,15 +263,16 @@
 		else
 			to_chat(user, "<span class='notice'>This cell is not fitted for [src].</span>")
 
-/obj/item/weapon/melee/baton/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/item/weapon/melee/baton/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
 	if(bcell)
-		results += "[desc_panel_image("offhand")]to remove the weapon cell."
+		results += "[desc_panel_image("offhand", for_chat)]to remove the weapon cell."
 	else
-		results += "[desc_panel_image("weapon cell")]to add a new weapon cell."
+		results += "[desc_panel_image("weapon cell", for_chat)]to add a new weapon cell."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results
 

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -36,10 +36,11 @@
 		if(LARGE_HOLE)
 			. += "It has been completely cut through."
 
-/obj/structure/fence/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/structure/fence/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 	if(cuttable && !invulnerable && hole_size < MAX_HOLE_SIZE)
-		results += "[desc_panel_image("wirecutters")]to [hole_size > NO_HOLE ? "expand the":"cut a"] hole into the fence, allowing passage."
+		results += "[desc_panel_image("wirecutters", for_chat)]to [hole_size > NO_HOLE ? "expand the":"cut a"] hole into the fence, allowing passage."
 	return results
 
 /obj/structure/fence/end

--- a/code/game/objects/structures/flora/trees.dm
+++ b/code/game/objects/structures/flora/trees.dm
@@ -129,13 +129,14 @@
 	adjust_health(-power / 100, TRUE) // Kills most trees in one lightning strike.
 	..()
 
-/obj/structure/flora/tree/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/structure/flora/tree/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
 	if(!is_stump)
-		results += "[desc_panel_image("hatchet")]to cut down this tree into logs.  Any sharp and strong weapon will do."
+		results += "[desc_panel_image("hatchet", for_chat)]to cut down this tree into logs.  Any sharp and strong weapon will do."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -199,7 +199,7 @@ var/list/preferences_datums = list()
 	var/lastnews // Hash of last seen lobby news content.
 	var/lastlorenews //ID of last seen lore news article.
 
-	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
+	var/examine_text_mode = 0 // Just examine text, include extended information, switch to examine panel. || RS Edit: Examine Mode Fix (Lira, July 2026)
 	var/multilingual_mode = 0 // Default behaviour, delimiter-key-space, delimiter-key-delimiter, off
 
 	var/list/volume_channels = list()

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -574,7 +574,7 @@
 			to_chat(src, "<span class='filter_system'>Examining things will only output the base examine text, and you will not be redirected to the examine panel automatically.</span>")
 
 		if(EXAMINE_MODE_INCLUDE_USAGE)
-			to_chat(src, "<span class='filter_system'>Examining things will also print any extra usage information normally included in the examine panel to the chat.</span>")
+			to_chat(src, "<span class='filter_system'>Examining things will also print extended information normally included in the examine panel to the chat.</span>") // RS Edit: Examine Mode Fix (Lira, July 2026)
 
 		if(EXAMINE_MODE_SWITCH_TO_PANEL)
 			to_chat(src, "<span class='filter_system'>Examining things will direct you to the examine panel, where you can view extended information about the thing.</span>")

--- a/code/modules/examine/descriptions/armor.dm
+++ b/code/modules/examine/descriptions/armor.dm
@@ -44,54 +44,56 @@
 			return "It's difficult to tell how much it'll influence your speed."
 
 
+// RS Edit: Examine Mode Fix (Lira, July 2026)
 /obj/item/clothing/get_description_info()
-	var/armor_stats = description_info + "\
-	<br>"
+	var/list/armor_stats = list()
+	if(description_info)
+		armor_stats += description_info
 
 	if(armor["melee"])
-		armor_stats += "[describe_armor("melee","blunt force")] \n"
+		armor_stats += describe_armor("melee", "blunt force")
 	if(armor["bullet"])
-		armor_stats += "[describe_armor("bullet","ballistics")] \n"
+		armor_stats += describe_armor("bullet", "ballistics")
 	if(armor["laser"])
-		armor_stats += "[describe_armor("laser","lasers")] \n"
+		armor_stats += describe_armor("laser", "lasers")
 	if(armor["energy"])
-		armor_stats += "[describe_armor("energy","energy")] \n"
+		armor_stats += describe_armor("energy", "energy")
 	if(armor["bomb"])
-		armor_stats += "[describe_armor("bomb","explosions")] \n"
+		armor_stats += describe_armor("bomb", "explosions")
 	if(armor["bio"])
-		armor_stats += "[describe_armor("bio","biohazards")] \n"
+		armor_stats += describe_armor("bio", "biohazards")
 	if(armor["rad"])
-		armor_stats += "[describe_armor("rad","radiation")] \n"
+		armor_stats += describe_armor("rad", "radiation")
 
-	armor_stats += "\n"
-
-	armor_stats += "[describe_slowdown()] \n"
+	if(armor_stats.len)
+		armor_stats.Add(null)
+	armor_stats += describe_slowdown()
 
 	if(flags & AIRTIGHT)
-		armor_stats += "It is airtight. \n"
+		armor_stats += "It is airtight."
 
 	if(min_pressure_protection == 0 && max_pressure_protection >= WARNING_HIGH_PRESSURE)	//0 to 325
-		armor_stats += "Wearing this will protect you from the vacuum of space and from high pressures. \n"
+		armor_stats += "Wearing this will protect you from the vacuum of space and from high pressures."
 	else if(min_pressure_protection <= WARNING_LOW_PRESSURE && max_pressure_protection >= WARNING_HIGH_PRESSURE) //50 to 325
-		armor_stats += "Wearing this will protect you from both low and high pressures, but not the vacuum of space. \n"
+		armor_stats += "Wearing this will protect you from both low and high pressures, but not the vacuum of space."
 	else if(min_pressure_protection == 0)
-		armor_stats += "Wearing this will protect you from the vacuum of space. \n"
+		armor_stats += "Wearing this will protect you from the vacuum of space."
 	else if(min_pressure_protection <= WARNING_LOW_PRESSURE) //50 or below
-		armor_stats += "Wearing this will protect you from low pressures, but not the vacuum of space. \n"
+		armor_stats += "Wearing this will protect you from low pressures, but not the vacuum of space."
 	else if(max_pressure_protection >= WARNING_HIGH_PRESSURE) //325 or higher
-		armor_stats += "Wearing this will protect you from high pressures. \n"
+		armor_stats += "Wearing this will protect you from high pressures."
 
 	if(flags & THICKMATERIAL)	//stops syringes
-		armor_stats += "The material is exceptionally thick. \n"
+		armor_stats += "The material is exceptionally thick."
 
 	if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //30000 or higher and as low as 2
-		armor_stats += "It provides exceptional protection from extremely high and low temperatures alike. \n"
+		armor_stats += "It provides exceptional protection from extremely high and low temperatures alike."
 	else if(max_heat_protection_temperature >= SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //5000 or above, but less than 30000
-		armor_stats += "It provides very good protection against hazardous temperatures at both extremes, but may not be sufficient for very high-intensity situations. \n"
+		armor_stats += "It provides very good protection against hazardous temperatures at both extremes, but may not be sufficient for very high-intensity situations."
 	else if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)	//30000 or above
-		armor_stats += "It provides exceptional protection from extremely high temperatures. \n"
+		armor_stats += "It provides exceptional protection from extremely high temperatures."
 	else if(min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE)	//2 or less
-		armor_stats += "It provides exceptional protection against very low temperatures. \n"
+		armor_stats += "It provides exceptional protection against very low temperatures."
 
 	var/list/covers = list()
 	var/list/slots = list()
@@ -105,9 +107,9 @@
 			slots += name
 
 	if(covers.len)
-		armor_stats += "It covers the [english_list(covers)]. \n"
+		armor_stats += "It covers the [english_list(covers)]."
 
 	if(slots.len)
-		armor_stats += "It can be worn on your [english_list(slots)]. \n"
+		armor_stats += "It can be worn on your [english_list(slots)]."
 
-	return armor_stats
+	return armor_stats.Join("\n")

--- a/code/modules/examine/descriptions/engineering.dm
+++ b/code/modules/examine/descriptions/engineering.dm
@@ -35,46 +35,49 @@
 	description_info = "Click the door to open or close it.  It only stops air while closed.<br>\
 	To remove these safely, use the 'deflate' verb.  Hitting these with any objects will probably puncture and break it forever."
 
-/obj/machinery/door/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/machinery/door/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 	if(!repairing && (health < maxhealth) && !(stat & BROKEN))
-		results += "[desc_panel_image("metal sheet")]to start repairing damage (May require different material type)."
+		results += "[desc_panel_image("metal sheet", for_chat)]to start repairing damage (May require different material type)."
 	if(repairing && density)
-		results += "[desc_panel_image("welder")]to finish repairs."
-		results += "[desc_panel_image("crowbar")]to undo adding sheets for repairs."
+		results += "[desc_panel_image("welder", for_chat)]to finish repairs."
+		results += "[desc_panel_image("crowbar", for_chat)]to undo adding sheets for repairs."
 
 	return results
 
-/obj/machinery/door/airlock/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/machinery/door/airlock/get_description_interaction(var/for_chat = FALSE)
 	description_info = "To ring an airlock's doorbell, hold Alt and click on the airlock with the Left Mouse Button on Green/Help intent.  Doing the same on Harm intent will instead hammer on the airlock." //vorestation edit
 	
 	var/list/results = list()
 
 	if(can_remove_electronics())
-		results += "[desc_panel_image("crowbar")]to remove the airlock electronics."
+		results += "[desc_panel_image("crowbar", for_chat)]to remove the airlock electronics."
 	else
-		results += "[desc_panel_image("crowbar")]to open or close if unpowered/broken, and unbolted."
+		results += "[desc_panel_image("crowbar", for_chat)]to open or close if unpowered/broken, and unbolted."
 
 	if(welded)
-		results += "[desc_panel_image("welder")]to unweld, allowing it to open again."
+		results += "[desc_panel_image("welder", for_chat)]to unweld, allowing it to open again."
 	else
-		results += "[desc_panel_image("welder")]to weld, preventing it from opening."
+		results += "[desc_panel_image("welder", for_chat)]to weld, preventing it from opening."
 
 	if(p_open)
-		results += "[desc_panel_image("screwdriver")]to close the wire panel."
-		results += "[desc_panel_image("wirecutters")]to cut an internal wire while hacking."
-		results += "[desc_panel_image("multitool")]to pulse an internal wire while hacking."
+		results += "[desc_panel_image("screwdriver", for_chat)]to close the wire panel."
+		results += "[desc_panel_image("wirecutters", for_chat)]to cut an internal wire while hacking."
+		results += "[desc_panel_image("multitool", for_chat)]to pulse an internal wire while hacking."
 	else
-		results += "[desc_panel_image("screwdriver")]to open the wire panel, enabling the ability to hack."
+		results += "[desc_panel_image("screwdriver", for_chat)]to open the wire panel, enabling the ability to hack."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results
 
-/obj/machinery/portable_atmospherics/canister/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/machinery/portable_atmospherics/canister/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
-	results += "[desc_panel_image("wrench")]to connect or disconnect from a connector port below."
-	results += "[desc_panel_image("air tank")]to fill the air tank from this canister."
+	results += "[desc_panel_image("wrench", for_chat)]to connect or disconnect from a connector port below."
+	results += "[desc_panel_image("air tank", for_chat)]to fill the air tank from this canister."
 
 	return results

--- a/code/modules/examine/descriptions/guns.dm
+++ b/code/modules/examine/descriptions/guns.dm
@@ -101,14 +101,16 @@
 		if(51 to 100)
 			return "an extremely long delay"
 
+// RS Edit: Examine Mode Fix (Lira, July 2026)
 /obj/item/weapon/gun/get_description_info()
 	var/is_loaded
 	var/non_lethal
 	var/non_lethal_list = list(/obj/item/weapon/gun/energy/medigun,/obj/item/weapon/gun/energy/mouseray,/obj/item/weapon/gun/energy/temperature,/obj/item/weapon/gun/energy/sizegun,/obj/item/weapon/gun/projectile/shotgun/pump/toy,/obj/item/weapon/gun/projectile/revolver/toy,/obj/item/weapon/gun/projectile/pistol/toy,/obj/item/weapon/gun/projectile/automatic/toy)
 	var/less_lethal
 	var/less_lethal_list = list(/obj/item/weapon/gun/energy/taser,/obj/item/weapon/gun/energy/stunrevolver,/obj/item/weapon/gun/energy/plasmastun,/obj/item/weapon/gun/energy/bfgtaser)
-	var/weapon_stats = description_info + "\
-	<br>"
+	var/list/weapon_stats = list()
+	if(description_info)
+		weapon_stats += description_info
 	if(istype(src, /obj/item/weapon/gun/energy))
 		is_loaded = LAZYLEN(src.contents)
 	if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
@@ -135,18 +137,18 @@
 			non_lethal = TRUE
 
 	if(is_loaded)
-		weapon_stats += "\nIf fired, it would deal [describe_firepower()] damage, [describe_proj_penetration()], and has [describe_firerate()] between shots."
+		weapon_stats += "If fired, it would deal [describe_firepower()] damage, [describe_proj_penetration()], and has [describe_firerate()] between shots."
 	else if(less_lethal)
-		weapon_stats += "\nIf fired, it would deal stunning damage to incapacitate targets, and has [describe_firerate()] between shots."
+		weapon_stats += "If fired, it would deal stunning damage to incapacitate targets, and has [describe_firerate()] between shots."
 	else if(non_lethal)
-		weapon_stats += "\nThis is an entirely non-lethal weapon, such as a mouseray, toy, or sizegun! Its effects cannot easily be quantified."
+		weapon_stats += "This is an entirely non-lethal weapon, such as a mouseray, toy, or sizegun! Its effects cannot easily be quantified."
 	else
-		weapon_stats += "\nIt isn't loaded!"
+		weapon_stats += "It isn't loaded!"
 	if(force)
-		weapon_stats += "\nIf used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
+		weapon_stats += "If used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
 	if(can_cleave)
-		weapon_stats += "\nIt is capable of hitting multiple targets with a single swing."
+		weapon_stats += "It is capable of hitting multiple targets with a single swing."
 	if(reach > 1)
-		weapon_stats += "\nIt can attack targets up to [reach] tiles away, and can attack over certain objects."
+		weapon_stats += "It can attack targets up to [reach] tiles away, and can attack over certain objects."
 
-	return weapon_stats
+	return weapon_stats.Join("\n")

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -75,17 +75,19 @@
 	else
 		return "an average attack speed"
 
+// RS Edit: Examine Mode Fix (Lira, July 2026)
 /obj/item/get_description_info()
-	var/weapon_stats = description_info + "\
-	<br>"
+	var/list/weapon_stats = list()
+	if(description_info)
+		weapon_stats += description_info
 
 	if(force)
-		weapon_stats += "\nIf used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
+		weapon_stats += "If used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
 	if(throwforce)
-		weapon_stats += "\nIf thrown, it would deal [describe_throwpower()] [sharp ? "sharp" : "blunt"] damage."
+		weapon_stats += "If thrown, it would deal [describe_throwpower()] [sharp ? "sharp" : "blunt"] damage."
 	if(can_cleave)
-		weapon_stats += "\nIt is capable of hitting multiple targets with a single swing."
+		weapon_stats += "It is capable of hitting multiple targets with a single swing."
 	if(reach > 1)
-		weapon_stats += "\nIt can attack targets up to [reach] tiles away, and can attack over certain objects."
+		weapon_stats += "It can attack targets up to [reach] tiles away, and can attack over certain objects."
 
-	return weapon_stats
+	return weapon_stats.Join("\n")

--- a/code/modules/examine/descriptions/turfs.dm
+++ b/code/modules/examine/descriptions/turfs.dm
@@ -1,35 +1,36 @@
 /turf/simulated/wall
 	description_info = "You can build a wall by using metal sheets and making a girder, then adding more metal or plasteel."
 
-/turf/simulated/wall/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/turf/simulated/wall/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 	if(damage)
-		results += "[desc_panel_image("welder")]to repair."
+		results += "[desc_panel_image("welder", for_chat)]to repair."
 
 	if(isnull(construction_stage) || !reinf_material)
-		results += "[desc_panel_image("welder")]to deconstruct if undamaged."
+		results += "[desc_panel_image("welder", for_chat)]to deconstruct if undamaged."
 	else
 		switch(construction_stage)
 			if(6)
-				results += "[desc_panel_image("wirecutters")]to begin deconstruction."
+				results += "[desc_panel_image("wirecutters", for_chat)]to begin deconstruction."
 			if(5)
 				results += list(
-					"[desc_panel_image("screwdriver")]to continue deconstruction.",
-					"[desc_panel_image("wirecutters")]to reverse deconstruction."
+					"[desc_panel_image("screwdriver", for_chat)]to continue deconstruction.",
+					"[desc_panel_image("wirecutters", for_chat)]to reverse deconstruction."
 					)
 			if(4)
 				results += list(
-					"[desc_panel_image("welder")]to continue deconstruction.",
-					"[desc_panel_image("screwdriver")]to reverse deconstruction."
+					"[desc_panel_image("welder", for_chat)]to continue deconstruction.",
+					"[desc_panel_image("screwdriver", for_chat)]to reverse deconstruction."
 					)
 			if(3)
-				results += "[desc_panel_image("crowbar")]to continue deconstruction."
+				results += "[desc_panel_image("crowbar", for_chat)]to continue deconstruction."
 			if(2)
-				results += "[desc_panel_image("wrench")]to continue deconstruction."
+				results += "[desc_panel_image("wrench", for_chat)]to continue deconstruction."
 			if(1)
-				results += "[desc_panel_image("welder")]to continue deconstruction."
+				results += "[desc_panel_image("welder", for_chat)]to continue deconstruction."
 			if(0)
-				results += "[desc_panel_image("crowbar")]to finish deconstruction."
+				results += "[desc_panel_image("crowbar", for_chat)]to finish deconstruction."
 	return results
 
 /turf/simulated/floor/get_description_info()
@@ -37,8 +38,10 @@
 	if(broken || burnt)
 		. += "It is broken."
 
-/turf/simulated/floor/get_description_interaction()
-	. = ..()
+// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+/turf/simulated/floor/get_description_interaction(var/for_chat = FALSE)
+	. = ..(for_chat)
+// RS Edit End
 	if(broken || burnt)
 		if(is_plating())
 			. += "Use a welder on it to repair the damage."
@@ -56,11 +59,16 @@
 		if(flooring.flags & TURF_REMOVE_SHOVEL)
 			. += "Use a shovel on it to remove it."
 
-/turf/simulated/floor/outdoors/snow/get_description_interaction()
-	. = ..()
+// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+/turf/simulated/floor/outdoors/snow/get_description_interaction(var/for_chat = FALSE)
+	. = ..(for_chat)
+// RS Edit End
 	. += "Use a shovel on it to get rid of the snow and reveal the ground beneath."
 	. += "Use an empty hand on it to scoop up some snow, which you can use to make snowballs or snowmen."
 
-/turf/simulated/floor/outdoors/grass/get_description_interaction()
-	. = "Use floor tiles on it to make a plating."  // using . = ..() would incorrectly say you can remove the grass with a shovel
-	. += "Use a shovel on it to dig for worms."
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/turf/simulated/floor/outdoors/grass/get_description_interaction(var/for_chat = FALSE)
+	return list(
+		"Use floor tiles on it to make a plating.", // using . = ..() would incorrectly say you can remove the grass with a shovel
+		"Use a shovel on it to dig for worms."
+		)

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -29,12 +29,23 @@
 	return
 
 // This one is slightly different, in that it must return a list.
-/atom/proc/get_description_interaction()
+/atom/proc/get_description_interaction(var/for_chat = FALSE) // RS Edit: Examine Mode Fix (Lira, July 2026)
 	return list()
 
 // Quickly adds the boilerplate code to add an image and padding for the image.
-/proc/desc_panel_image(var/icon_state)
-	return "\icon[description_icons[icon_state]][EXAMINE_PANEL_PADDING]"
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/proc/desc_panel_image(var/icon_state, var/for_chat = FALSE)
+	var/image/description_icon = description_icons[icon_state]
+	if(!description_icon)
+		return EXAMINE_PANEL_PADDING
+	if(!for_chat)
+		return "\icon[description_icon][EXAMINE_PANEL_PADDING]"
+
+	var/static/list/chat_icons = list()
+	if(!chat_icons[icon_state])
+		chat_icons[icon_state] = bicon(icon(description_icon.icon, description_icon.icon_state))
+	var/chat_icon = chat_icons[icon_state]
+	return "\icon[description_icon][chat_icon][EXAMINE_PANEL_PADDING]"
 
 /mob/living/get_description_fluff()
 	if(flavor_text) //Get flavor text for the green text.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -427,9 +427,17 @@
 		msg += "<span class='deptradio'>Employment records:</span> <a href='?src=\ref[src];emprecord=`'>\[View\]</a> <a href='?src=\ref[src];emprecordadd=`'>\[Add comment\]</a>"
 
 
-	var/flavor_text = print_flavor_text()
-	if(flavor_text)
-		msg += "[flavor_text]"
+	// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+	var/flavor_text
+	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
+		flavor_text = get_description_fluff()
+		if(flavor_text)
+			msg += span_green("<b>[flavor_text]</b>")
+	else
+		flavor_text = print_flavor_text()
+		if(flavor_text)
+			msg += "[flavor_text]"
+	// RS Edit End
 
 	// VOREStation Start
 	if(custom_link)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1424,12 +1424,14 @@
 		if(C.body_parts_covered & FEET)
 			feet_exposed = 0
 
-	flavor_text = ""
+	// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+	var/list/visible_flavor_texts = list()
 	for (var/T in flavor_texts)
 		if(flavor_texts[T] && flavor_texts[T] != "")
 			if((T == "general") || (T == "head" && head_exposed) || (T == "face" && face_exposed) || (T == "eyes" && eyes_exposed) || (T == "torso" && torso_exposed) || (T == "arms" && arms_exposed) || (T == "hands" && hands_exposed) || (T == "legs" && legs_exposed) || (T == "feet" && feet_exposed))
-				flavor_text += flavor_texts[T]
-				flavor_text += "\n\n"
+				visible_flavor_texts += flavor_texts[T]
+	flavor_text = visible_flavor_texts.Join("\n\n")
+	// RS Edit End
 	if(!shrink)
 		return flavor_text
 	else

--- a/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
@@ -310,7 +310,7 @@
 	color = new_skin
 	update_icon()
 
-/mob/living/simple_mob/slime/promethean/get_description_interaction()
+/mob/living/simple_mob/slime/promethean/get_description_interaction(var/for_chat = FALSE) // RS Edit: Examine Mode Fix (Lira, July 2026)
 	return
 
 

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -9,7 +9,12 @@
 
 	// VOREStation Edit: Start
 	. += attempt_vr(src,"examine_bellies",args) //VOREStation Edit
-	if(print_flavor_text()) . += "\n[print_flavor_text()]\n"
+	// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+	if(user.client?.prefs.examine_text_mode != EXAMINE_MODE_INCLUDE_USAGE)
+		var/flavor_text = print_flavor_text()
+		if(flavor_text)
+			. += "\n[flavor_text]\n"
+	// RS Edit End
 	// VOREStation Edit: End
 	. += "*---------*"
 	if (pose)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -36,7 +36,12 @@
 
 	. += "*---------*"
 
-	if(print_flavor_text()) . += "<br>[print_flavor_text()]"
+	// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+	if(user.client?.prefs.examine_text_mode != EXAMINE_MODE_INCLUDE_USAGE)
+		var/flavor_text = print_flavor_text()
+		if(flavor_text)
+			. += "<br>[flavor_text]"
+	// RS Edit End
 
 	if (pose)
 		if(!findtext(pose, regex("\[.?!]$"))) // Will be zero if the last character is not a member of [.?!]

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -609,7 +609,7 @@
 	adjust_discipline(round(amount/2))
 	power_charge = between(0, power_charge + amount, 10)
 
-/mob/living/simple_mob/slime/xenobio/gold/get_description_interaction() // So it doesn't say to use a baton on them.
+/mob/living/simple_mob/slime/xenobio/gold/get_description_interaction(var/for_chat = FALSE) // So it doesn't say to use a baton on them. || RS Edit: Examine Mode Fix (Lira, July 2026)
 	return list()
 
 

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
@@ -283,13 +283,14 @@
 		step_away(baby, src)
 	return baby
 
-/mob/living/simple_mob/slime/xenobio/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/mob/living/simple_mob/slime/xenobio/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
 	if(!stat)
-		results += "[desc_panel_image("slimebaton")]to stun the slime, if it's being bad."
+		results += "[desc_panel_image("slimebaton", for_chat)]to stun the slime, if it's being bad."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results
 

--- a/code/modules/power/lightswitch_vr.dm
+++ b/code/modules/power/lightswitch_vr.dm
@@ -156,18 +156,19 @@
 		return
 	. = ..()
 
-/obj/structure/construction/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/structure/construction/get_description_interaction(var/for_chat = FALSE)
 	. = list()
 	switch(stage)
 		if(FRAME_UNFASTENED)
 			. += list(
-				"[desc_panel_image("screwdriver")]to continue construction.",
-				"[desc_panel_image("welder")]to deconstruct.")
+				"[desc_panel_image("screwdriver", for_chat)]to continue construction.",
+				"[desc_panel_image("welder", for_chat)]to deconstruct.")
 		if(FRAME_FASTENED)
 			. += list(
-				"[desc_panel_image("cable coil")]to continue construction.",
-				"[desc_panel_image("screwdriver")]to reverse construction.")
+				"[desc_panel_image("cable coil", for_chat)]to continue construction.",
+				"[desc_panel_image("screwdriver", for_chat)]to reverse construction.")
 		if(FRAME_WIRED)
 			. += list(
-				"[desc_panel_image("screwdriver")]to finish construction.",
-				"[desc_panel_image("wirecutters")]to reverse construction.")
+				"[desc_panel_image("screwdriver", for_chat)]to finish construction.",
+				"[desc_panel_image("wirecutters", for_chat)]to reverse construction.")

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -235,16 +235,17 @@
 	START_PROCESSING(SSobj, src)
 	update_icon()
 
-/obj/item/weapon/gun/energy/get_description_interaction()
+// RS Edit: Examine Mode Fix (Lira, July 2026)
+/obj/item/weapon/gun/energy/get_description_interaction(var/for_chat = FALSE)
 	var/list/results = list()
 
 	if(!battery_lock && !self_recharge)
 		if(power_supply)
-			results += "[desc_panel_image("offhand")]to remove the weapon cell."
+			results += "[desc_panel_image("offhand", for_chat)]to remove the weapon cell."
 		else
-			results += "[desc_panel_image("weapon cell")]to add a new weapon cell."
+			results += "[desc_panel_image("weapon cell", for_chat)]to add a new weapon cell."
 
-	results += ..()
+	results += ..(for_chat)
 
 	return results
 

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -961,6 +961,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		var/msg_text = entry["message"]
 		if(!istext(msg_text))
 			continue
+		msg_text = replacetext(msg_text, "\n", "<br>") // RS Add: Examine Mode Fix (Lira, July 2026)
 		var/logged_at = entry["logged_at"]
 		if(istext(logged_at))
 			logged_at = text2num(logged_at)

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -2165,8 +2165,10 @@ Departamental Swimsuits, for general use
 		return
 	..()
 
-/obj/item/clothing/head/fluff/nikki/get_description_interaction()
-	. = ..()
+// RS Edit Start: Examine Mode Fix (Lira, July 2026)
+/obj/item/clothing/head/fluff/nikki/get_description_interaction(var/for_chat = FALSE)
+	. = ..(for_chat)
+// RS Edit End
 	if (translocator)
 		. += "It has \a [translocator] inside of it. Alt-click while holding it on your inactive hand to remove it."
 		. += "Otherwise, this hat functions exactly as the translocator it has inside while still being a sweet head accessory."


### PR DESCRIPTION
## PR Purpose and Benefit
Fixes Examine Mode!  Examine Mode allows extra information to print into the chat window when you examine things.  It has been broken forever, but now it is unbroken!


## Development Checklist
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
- [x] The PR is atomic.
- [x] I am the author of this code and I am licensing it under AGPLv3.
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
Tested and works on local.  Had Soft test it as well.