### PR TITLE
spawner fix

### DIFF
--- a/code/game/Rogue Star/mob/seething.dm
+++ b/code/game/Rogue Star/mob/seething.dm
@@ -231,11 +231,10 @@
 
 /mob/living/simple_mob/hostile/seething/spawner/Life()
 	. = ..()
+	if(ai_holder.stance == STANCE_IDLE)
+		return
 	if(prob(10))
-		var/turf/T = get_turf(src)
-		if(T.check_density(FALSE,TRUE))
-			return
-		new /mob/living/simple_mob/hostile/seething(T)
+		spawn_seething()
 
 /mob/living/simple_mob/hostile/seething/spawner/try_reload()
 	warp(FALSE)


### PR DESCRIPTION
## PR Purpose and Benefit
Seething spawner now only spawns seething when it's not idle, that way it doesn't spawn thousands of them for me to bomb anymore


## Development Checklist
<!-- Please explain any unchecked boxes in Development Notes.  To check off each item, put an 'x' in the brackets. -->
- [x] I have read through and accept the contributing guidelines in the Discord.
- [x] I have submitted a project modmail or discussed my project with one of the Project Leads.
<!-- Not required, but strongly recommended. -->
- [x] The PR is atomic.
<!-- If it includes multiple parts, explain why you have bundled them together. -->
- [x] I am the author of this code and I am licensing it under AGPLv3.
<!-- If there are co-authors or the code is ported, please provide detail. -->
- [x] All included assets are safe for work and have been documented in `ATTRIBUTIONS.md`.
- [x] I am the creator of all included assets or have the permission of the creator to include them.
- [x] I have added `// RS Add/Edit` or equivalent tags to my code where the changes were not already in `// RS Add/Edit` or equivalent tags.
- [x] I have tested my code, both by compiling it and making sure it behaves as intended when run locally.


## Development Notes
